### PR TITLE
testConnectionTimeout fails when the network 192.168.0.0 is available…

### DIFF
--- a/eblocker-certificate-validator/src/test/java/org/eblocker/certificate/validator/http/DefaultHttpUrlConnectionBuilderTest.java
+++ b/eblocker-certificate-validator/src/test/java/org/eblocker/certificate/validator/http/DefaultHttpUrlConnectionBuilderTest.java
@@ -149,7 +149,8 @@ public class DefaultHttpUrlConnectionBuilderTest {
 
     @Test(expected = java.net.SocketTimeoutException.class)
     public void testConnectionTimeout() throws IOException {
-        HttpURLConnection connection = builder.setUrl("http://192.168.0.0:18080/get").setConnectionTimeout(50).get();
+        // 192.0.2.0/24 is reserved for documentation according to RFC 5737
+        HttpURLConnection connection = builder.setUrl("http://192.0.2.1:18080/get").setConnectionTimeout(50).get();
         connection.getResponseCode();
     }
 }


### PR DESCRIPTION
…. Use an IP address reserved for documentation (which should never be routed).