### PR TITLE
Set default value for license key in initial activation wizard

### DIFF
--- a/eblocker-ui/src/settings/app/components/activation/activation.component.js
+++ b/eblocker-ui/src/settings/app/components/activation/activation.component.js
@@ -50,7 +50,9 @@ function Controller(logger, StateService, STATES, $translate, settings, Timezone
         // configuredSettings.serial = !vm.setupWizardInfo.needSerialNumber;
         vm.registrationAvailable = vm.setupWizardInfo.registrationAvailable;
 
-        vm.registrationUserData = {};
+        vm.registrationUserData = {
+            licenseKey: 'FAMLFT-OPENSOURCE'
+        };
         setTosContent();
     };
 


### PR DESCRIPTION
This also sets the license key in the initial activation wizard, last PR only set it in the change license dialog