### PR TITLE
Ensure license tab can only be switch to after ToS have been accepted…

### DIFF
--- a/eblocker-ui/src/settings/app/components/activation/activation.component.js
+++ b/eblocker-ui/src/settings/app/components/activation/activation.component.js
@@ -300,9 +300,10 @@ function Controller(logger, StateService, STATES, $translate, settings, Timezone
             case 2:
                 return licenseAgreed;
             case 3:
+            case 4:
                 return licenseAgreed && vm.timezoneSet;
             default:
-                return vm.isTosValid() || vm.registrationAvailable;
+                return false;
         }
     }
 


### PR DESCRIPTION
… and time zone is defined: require same conditions as switching to device name tab

Fixes #33 