### PR TITLE
New mode to toggle auto-enabling of new devices.

### DIFF
--- a/eblocker-icapserver/src/main/java/org/eblocker/server/common/data/DataSource.java
+++ b/eblocker-icapserver/src/main/java/org/eblocker/server/common/data/DataSource.java
@@ -303,7 +303,10 @@ public interface DataSource {
     void setShowSplashScreen(boolean show);
     boolean isShowSplashScreen();
 
-	CompressionMode getCompressionMode();
+    void setAutoEnableNewDevices(boolean autoEnableNewDevices);
+    boolean isAutoEnableNewDevices();
+
+    CompressionMode getCompressionMode();
 	void setCompressionMode(CompressionMode compressionMode);
 
     boolean getSslRecordErrors();

--- a/eblocker-icapserver/src/main/java/org/eblocker/server/common/data/DeviceFactory.java
+++ b/eblocker-icapserver/src/main/java/org/eblocker/server/common/data/DeviceFactory.java
@@ -60,10 +60,22 @@ public class DeviceFactory {
         device.setId(deviceId);
         device.setIpAddresses(ipAddresses);
         String hardwareAddressPrefix = device.getHardwareAddressPrefix();
-        device.setEnabled(!isDisabledByDefault(hardwareAddressPrefix));
+        device.setEnabled(isEnabledByDefault(hardwareAddressPrefix));
         device.setIpAddressFixed(fixed);
         device.setName(createNameForNewDevice(hardwareAddressPrefix));
         return device;
+    }
+
+    private boolean isEnabledByDefault(String hardwareAddressPrefix) {
+        return isAutoEnableNewDevices() && !isDisabledByDefaultBasedOnMac(hardwareAddressPrefix);
+    }
+
+    public void setAutoEnableNewDevices(boolean isAutoEnableNewDevices) {
+        dataSource.setAutoEnableNewDevices(isAutoEnableNewDevices);
+    }
+
+    public boolean isAutoEnableNewDevices() {
+        return dataSource.isAutoEnableNewDevices();
     }
 
     public String createNameForNewDevice(String hardwareAddressPrefix) {
@@ -91,8 +103,7 @@ public class DeviceFactory {
         return "";
     }
 
-   private boolean isDisabledByDefault(String macAdressPrefix){
+   private boolean isDisabledByDefaultBasedOnMac(String macAdressPrefix){
        return disabledByDefault.getVendor(macAdressPrefix) != null;
    }
-
 }

--- a/eblocker-icapserver/src/main/java/org/eblocker/server/common/data/JedisDataSource.java
+++ b/eblocker-icapserver/src/main/java/org/eblocker/server/common/data/JedisDataSource.java
@@ -79,6 +79,7 @@ public class JedisDataSource implements DataSource {
     private static final String KEY_DNT_HEADER_STATE = "dnt_header_enabled";
     private static final String KEY_DO_NOT_SHOW_REMINDER = "do_not_show_reminder";
     private static final String KEY_SHOW_SPLASH_SCREEN = "showSplashScreen";
+    private static final String KEY_AUTO_ENABLE_NEW_DEVICES = "autoEnableNewDevices";
     private static final String KEY_COMPRESSION_MODE = "compression_mode";
     private static final String KEY_LAST_SSL_DEFAULT_WHITELIST_UPDATE = "ssl_default_whitelist_date";
     private static final String KEY_LAST_APPMODULES_DEFAULT_FILE_UPDATE = "appmodules_default_json_file_update";
@@ -1133,6 +1134,23 @@ public class JedisDataSource implements DataSource {
         return true;
     }
 
+    @Override
+    public void setAutoEnableNewDevices(boolean autoEnableNewDevices) {
+        try (Jedis jedis = pool.getResource()) {
+            jedis.set(KEY_AUTO_ENABLE_NEW_DEVICES, autoEnableNewDevices ? VALUE_TRUE : VALUE_FALSE);
+        }
+    }
+
+    @Override
+    public boolean isAutoEnableNewDevices() {
+        try (Jedis jedis = pool.getResource()) {
+            String autoEnableNewDevices = jedis.get(KEY_AUTO_ENABLE_NEW_DEVICES);
+            if (autoEnableNewDevices != null) {
+                return autoEnableNewDevices.equals(VALUE_TRUE);
+            }
+        } // default
+        return true;
+    }
     @Override
     public CompressionMode getCompressionMode() {
         try(Jedis jedis = pool.getResource()) {

--- a/eblocker-icapserver/src/main/java/org/eblocker/server/http/controller/DeviceController.java
+++ b/eblocker-icapserver/src/main/java/org/eblocker/server/http/controller/DeviceController.java
@@ -45,6 +45,10 @@ public interface DeviceController {
 
     void setScanningInterval(Request request, Response response);
 
+    Boolean isAutoEnableNewDevices(Request request, Response response);
+
+    void setAutoEnableNewDevices(Request request, Response response);
+
     RemainingPause getPauseByDeviceId(Request request, Response response);
 
     RemainingPause setPauseByDeviceId(Request request, Response response);

--- a/eblocker-icapserver/src/main/java/org/eblocker/server/http/controller/impl/DeviceControllerImpl.java
+++ b/eblocker-icapserver/src/main/java/org/eblocker/server/http/controller/impl/DeviceControllerImpl.java
@@ -18,6 +18,7 @@ package org.eblocker.server.http.controller.impl;
 
 import org.eblocker.server.common.PauseDeviceController;
 import org.eblocker.server.common.data.Device;
+import org.eblocker.server.common.data.DeviceFactory;
 import org.eblocker.server.common.data.IconSettings;
 import org.eblocker.server.common.data.IpAddress;
 import org.eblocker.server.common.data.ShowWelcomeFlags;
@@ -61,6 +62,7 @@ public class DeviceControllerImpl implements DeviceController {
 	private final NetworkStateMachine networkStateMachine;
 	private final OpenVpnService openVpnService;
 	private final PauseDeviceController pauseDeviceController;
+	private final DeviceFactory deviceFactory;
 
 	@Inject
 	public DeviceControllerImpl(AnonymousService anonymousService,
@@ -73,8 +75,8 @@ public class DeviceControllerImpl implements DeviceController {
                                 NetworkInterfaceWrapper networkInterfaceWrapper,
                                 NetworkStateMachine networkStateMachine,
                                 OpenVpnService openVpnService,
-                                PauseDeviceController pauseDeviceController
-                                ) {
+                                PauseDeviceController pauseDeviceController,
+                                DeviceFactory deviceFactory) {
 		this.anonymousService = anonymousService;
 		this.deviceOnlineStatusCache = deviceOnlineStatusCache;
 		this.devicePermissionsService = devicePermissionsService;
@@ -86,7 +88,8 @@ public class DeviceControllerImpl implements DeviceController {
 		this.networkStateMachine = networkStateMachine;
 		this.openVpnService = openVpnService;
 		this.pauseDeviceController = pauseDeviceController;
-	}
+        this.deviceFactory = deviceFactory;
+    }
 
 	@Override
     public Object deleteDevice(Request request, Response response) {
@@ -292,6 +295,17 @@ public class DeviceControllerImpl implements DeviceController {
         if (interval >= 0) {
             deviceScanningService.setScanningInterval(interval);
         }
+    }
+
+    @Override
+    public Boolean isAutoEnableNewDevices(Request request, Response response) {
+	    return deviceFactory.isAutoEnableNewDevices();
+    }
+
+    @Override
+    public void setAutoEnableNewDevices(Request request, Response response) {
+        Boolean isAutoEnableNewDevices = request.getBodyAs(Boolean.class);
+        deviceFactory.setAutoEnableNewDevices(isAutoEnableNewDevices);
     }
 
     @Override

--- a/eblocker-icapserver/src/main/java/org/eblocker/server/http/server/EblockerHttpsServer.java
+++ b/eblocker-icapserver/src/main/java/org/eblocker/server/http/server/EblockerHttpsServer.java
@@ -1738,6 +1738,17 @@ public class EblockerHttpsServer implements Preprocessor {
             .uri("/api/adminconsole/devices/scanningInterval", deviceController)
             .action("setScanningInterval", HttpMethod.POST)
             .name("adminconsole.devices.set.scanning.interval");
+
+        server
+            .uri("/api/adminconsole/devices/autoEnableNewDevices", deviceController)
+            .action("isAutoEnableNewDevices", HttpMethod.GET)
+            .name("adminconsole.devices.get.auto.enable.new.devices");
+
+        server
+            .uri("/api/adminconsole/devices/autoEnableNewDevices", deviceController)
+            .action("setAutoEnableNewDevices", HttpMethod.POST)
+            .name("adminconsole.devices.set.auto.enable.new.devices");
+
         server
             .uri("/api/adminconsole/devices/{deviceId}", deviceController)
             .action("getDeviceById", HttpMethod.GET)

--- a/eblocker-icapserver/src/test/java/org/eblocker/server/common/data/MockDataSource.java
+++ b/eblocker-icapserver/src/test/java/org/eblocker/server/common/data/MockDataSource.java
@@ -546,18 +546,28 @@ public class MockDataSource implements DataSource {
     @Override
     public void setOpenVpnPortForwardingMode(PortForwardingMode mode) {
         // TODO Auto-generated method stub
-        
+
     }
 
     @Override
     public void setShowSplashScreen(boolean show) {
         // TODO Auto-generated method stub
-        
+
     }
 
     @Override
     public boolean isShowSplashScreen() {
         // TODO Auto-generated method stub
+        return false;
+    }
+
+    @Override
+    public void setAutoEnableNewDevices(boolean autoEnableNewDevices) {
+
+    }
+
+    @Override
+    public boolean isAutoEnableNewDevices() {
         return false;
     }
 

--- a/eblocker-icapserver/src/test/java/org/eblocker/server/http/controller/impl/DeviceControllerImplTest.java
+++ b/eblocker-icapserver/src/test/java/org/eblocker/server/http/controller/impl/DeviceControllerImplTest.java
@@ -18,6 +18,7 @@ package org.eblocker.server.http.controller.impl;
 
 import org.eblocker.server.common.PauseDeviceController;
 import org.eblocker.server.common.data.Device;
+import org.eblocker.server.common.data.DeviceFactory;
 import org.eblocker.server.common.data.IpAddress;
 import org.eblocker.server.common.data.ShowWelcomeFlags;
 import org.eblocker.server.common.data.TestDeviceFactory;
@@ -66,6 +67,7 @@ public class DeviceControllerImplTest {
 	private DeviceScanningService deviceScanningService;
 	private DeviceService deviceService;
 	private DeviceRegistrationProperties deviceRegistrationProperties;
+	private DeviceFactory deviceFactory;
 	private FeatureToggleRouter featureToggleRouter;
 	private NetworkInterfaceWrapper networkInterfaceWrapper;
 	private NetworkStateMachine networkStateMachine;
@@ -82,6 +84,7 @@ public class DeviceControllerImplTest {
 		deviceScanningService = Mockito.mock(DeviceScanningService.class);
 		deviceService = Mockito.mock(DeviceService.class);
         deviceRegistrationProperties = Mockito.mock(DeviceRegistrationProperties.class);
+        deviceFactory = Mockito.mock(DeviceFactory.class);
 
         featureToggleRouter = Mockito.mock(FeatureToggleRouter.class);
         Mockito.when(featureToggleRouter.isIp6Enabled()).thenReturn(true);
@@ -105,17 +108,18 @@ public class DeviceControllerImplTest {
 		tdf.commit();
 
 		controller = new DeviceControllerImpl(
-				anonymousService,
-				deviceOnlineStatusCache,
-				devicePermissionsService,
-				deviceScanningService,
-				deviceService,
+                anonymousService,
+                deviceOnlineStatusCache,
+                devicePermissionsService,
+                deviceScanningService,
+                deviceService,
                 deviceRegistrationProperties,
-				featureToggleRouter,
-				networkInterfaceWrapper,
-				networkStateMachine,
-				openVpnService,
-				pauseDeviceController);
+                featureToggleRouter,
+                networkInterfaceWrapper,
+                networkStateMachine,
+                openVpnService,
+                pauseDeviceController,
+                deviceFactory);
 	}
 
 

--- a/eblocker-ui/src/locale/lang-settings-de.json
+++ b/eblocker-ui/src/locale/lang-settings-de.json
@@ -37,6 +37,18 @@
                     "SERIAL_NUMBER_LABEL" : "Seriennummer des Gerätes",
                     "SERIAL_NUMBER_WRONG_FORMAT" : "Die Seriennummer ist nicht im erwarteten Format."
                 },
+                "AUTO_ENABLE_NEW_DEVICES" : {
+                    "LABEL" : "Neue Geräte",
+                    "TEXT1" : "Automatische Aktivierung neuer Geräte",
+                    "AUTO_ENABLE_NEW_DEVICES_ENABLED" : {
+                        "TITLE" : "Neue Geräte automatisch aktivieren",
+                        "TEXT" : "In diesem Modus wird der eBlocker für neue Geräte automatisch aktiviert (nicht empfohlen)."
+                    },
+                    "AUTO_ENABLE_NEW_DEVICES_DISABLED" : {
+                        "TITLE" : "Neue Geräte nicht automatisch aktivieren",
+                        "TEXT" : "In diesem Modus ist der eBlocker für neue Geräte nicht aktiviert (empfohlen). Bitte aktivieren Sie die Geräte jeweils manuell im eBlocker (Einstellungen>Geräte)."
+                    }
+                },
                 "LICENSE" : {
                     "EMAIL_IMPORTANCE_EXPLAIN_PART1" : "Wenn Ihr eBlocker auf eBlocker.com gekauft wurde, verwenden Sie bitte die E-Mail Adresse, an die der Lizenzschlüssel gesendet wurde.",
                     "EMAIL_IMPORTANCE_EXPLAIN_PART2" : "Falls Sie den eBlocker <b>nicht</b> auf eBlocker.com erworben oder selbst gebaut haben, geben Sie bitte eine langfristig gültige E-Mail ein. Diese wird ausschließlich für administrative Zwecke, wie die Zusendung eines Lizenzschlüssels, sowie im Supportfall verwendet.",
@@ -385,7 +397,12 @@
             },
             "LABEL" : "Geräte suchen",
             "SCAN_HEADER_AUTO" : "Automatische Suche nach neuen Geräten",
-            "SCAN_HEADER_MAN" : "Manuelle Suche nach neuen Geräten"
+            "SCAN_HEADER_MAN" : "Manuelle Suche nach neuen Geräten",
+            "AUTO_ENABLE_NEW_DEVICES" : {
+                "HEADER" : "Automatisches Aktivieren von neuen Geräten",
+                "ENABLED" : "Der eBlocker wird neue Geräte automatisch aktivieren",
+                "DISABLED" : "Der eBlocker wird neue Geräte nicht automatisch aktivieren"
+            }
         },
         "DEVICES_LIST" : {
             "ACTION" : {

--- a/eblocker-ui/src/locale/lang-settings-en.json
+++ b/eblocker-ui/src/locale/lang-settings-en.json
@@ -37,6 +37,18 @@
                     "SERIAL_NUMBER_LABEL" : "Device Serial Number",
                     "SERIAL_NUMBER_WRONG_FORMAT" : "The device serial number is not in the expected format."
                 },
+                "AUTO_ENABLE_NEW_DEVICES" : {
+                    "LABEL" : "New Devices",
+                    "TEXT1" : "Automatic activation of new devices",
+                    "AUTO_ENABLE_NEW_DEVICES_ENABLED" : {
+                        "TITLE" : "Automatically enable new devices",
+                        "TEXT" : "Using this mode, eBlocker will be automatically enabled for new devices detected in your network (not recommended)."
+                    },
+                    "AUTO_ENABLE_NEW_DEVICES_DISABLED" : {
+                        "TITLE" : "Do not automatically enable new devices",
+                        "TEXT" : "Using this mode, eBlocker will not be automatically enabled for new devices detected in your network (recommended). Please enable new devices manually in Settings>Devices."
+                    }
+                },
                 "LICENSE" : {
                     "EMAIL_IMPORTANCE_EXPLAIN_PART1" : "If your eBlocker was purchased on eBlocker.com, please use the email address to which the license key was sent.",
                     "EMAIL_IMPORTANCE_EXPLAIN_PART2" : "If you did <br>not</b> purchase the eBlocker on eBlocker.com or build eBlocker yourself, please enter a long-term valid email. This will only be used for administrative purposes, such as sending a license key, and for support.",
@@ -385,7 +397,12 @@
             },
             "LABEL" : "Device Discovery",
             "SCAN_HEADER_AUTO" : "Automatic device discovery",
-            "SCAN_HEADER_MAN" : "Manual device discovery"
+            "SCAN_HEADER_MAN" : "Manual device discovery",
+            "AUTO_ENABLE_NEW_DEVICES" : {
+                "HEADER": "Automatic enabling of new devices",
+                "ENABLED": "eBlocker will automatically enable new devices",
+                "DISABLED": "eBlocker will not automatically enable new devices"
+            }
         },
         "DEVICES_LIST" : {
             "ACTION" : {

--- a/eblocker-ui/src/settings/app/components/activation/activation.component.html
+++ b/eblocker-ui/src/settings/app/components/activation/activation.component.html
@@ -69,6 +69,14 @@
 
             <md-tab ng-disabled="!vm.isStepAllowed(4)">
                 <!-- TAB 4 -->
+                <md-tab-label>{{'ADMINCONSOLE.ACTIVATION.TAB.AUTO_ENABLE_NEW_DEVICES.LABEL' | translate}}</md-tab-label>
+                <md-tab-body>
+                    <ng-include src="'app/components/activation/auto-enable-new-devices-tab.component.html'"></ng-include>
+                </md-tab-body>
+            </md-tab>
+
+            <md-tab ng-disabled="!vm.isStepAllowed(5)">
+                <!-- TAB 5 -->
                 <md-tab-label>{{ 'ADMINCONSOLE.ACTIVATION.TAB.LICENSE.LABEL' | translate }}</md-tab-label>
                 <md-tab-body>
                     <ng-include src="'app/components/activation/license-tab.component.html'"></ng-include>

--- a/eblocker-ui/src/settings/app/components/activation/activation.component.js
+++ b/eblocker-ui/src/settings/app/components/activation/activation.component.js
@@ -26,7 +26,7 @@ export default {
 
 function Controller(logger, StateService, STATES, $translate, settings, TimezoneService, NotificationService, // jshint ignore: line
                     SetupService, TosService, RegistrationService, UrlService, $window, DialogService, LanguageService,
-                    $timeout, $q) {
+                    DeviceService, $timeout, $q) {
     'ngInject';
 
     const vm = this;
@@ -40,6 +40,8 @@ function Controller(logger, StateService, STATES, $translate, settings, Timezone
     vm.isTosConfirmed = false;
     vm.isNoRegistrationConfirmed = false;
     vm.timezoneSet = false;
+    vm.isAutoEnableNewDevices = false;
+    vm.isAutoEnableNewDevicesSet = false;
 
     vm.languages = settings.getSupportedLanguageList();
     vm.locale = settings.locale();
@@ -210,6 +212,20 @@ function Controller(logger, StateService, STATES, $translate, settings, Timezone
     }
     // END TAB DEVICE
 
+    // TAB AUTO ENABLE NEW DEVICES
+
+    vm.submitAutoEnableNewDevicesForm = submitAutoEnableNewDevicesForm;
+    function submitAutoEnableNewDevicesForm() {
+        DeviceService.setAutoEnableNewDevices(vm.isAutoEnableNewDevices).then(function (response) {
+            vm.isAutoEnableNewDevicesSet = true;
+            nextStep();
+        }, function(data) {
+            logger.error('setAutoEnableNewDevices failed ', data);
+        });
+    }
+
+    // END TAB AUTO ENABLE NEW DEVICES
+
     // TAB LICENSE
     vm.submitLicenseForm = submitLicenseForm;
     function submitLicenseForm() {
@@ -301,8 +317,12 @@ function Controller(logger, StateService, STATES, $translate, settings, Timezone
                 return licenseAgreed;
             case 3:
                 return licenseAgreed && vm.timezoneSet;
+            case 4:
+                return licenseAgreed && vm.timezoneSet;
+            case 5:
+                return licenseAgreed && vm.timezoneSet && vm.isAutoEnableNewDevicesSet;
             default:
-                return vm.isTosValid() || vm.registrationAvailable;
+                return false;
         }
     }
 

--- a/eblocker-ui/src/settings/app/components/activation/auto-enable-new-devices-tab.component.html
+++ b/eblocker-ui/src/settings/app/components/activation/auto-enable-new-devices-tab.component.html
@@ -1,0 +1,39 @@
+<div layout-padding layout="column">
+    <h4>{{ 'ADMINCONSOLE.ACTIVATION.TAB.AUTO_ENABLE_NEW_DEVICES.TEXT1' | translate }}</h4>
+
+    <form name="vm.autoEnableNewDevicesForm" ng-submit="vm.submitAutoEnableNewDevicesForm()">
+        <md-radio-group md-theme="eBlockerThemeRadio" class="md-primary" ng-model="vm.isAutoEnableNewDevices">
+            <md-radio-button class="md-accent" ng-value="true">
+                <h4 style="margin: 0;">{{
+                    'ADMINCONSOLE.ACTIVATION.TAB.AUTO_ENABLE_NEW_DEVICES.AUTO_ENABLE_NEW_DEVICES_ENABLED.TITLE' | translate
+                    }}</h4>
+                <div>{{ 'ADMINCONSOLE.ACTIVATION.TAB.AUTO_ENABLE_NEW_DEVICES.AUTO_ENABLE_NEW_DEVICES_ENABLED.TEXT' |
+                    translate
+                    }}
+                </div>
+            </md-radio-button>
+
+            <md-radio-button class="md-accent" ng-value="false">
+                <h4 style="margin: 0;">{{
+                    'ADMINCONSOLE.ACTIVATION.TAB.AUTO_ENABLE_NEW_DEVICES.AUTO_ENABLE_NEW_DEVICES_DISABLED.TITLE' |
+                    translate
+                    }}</h4>
+                <div>{{ 'ADMINCONSOLE.ACTIVATION.TAB.AUTO_ENABLE_NEW_DEVICES.AUTO_ENABLE_NEW_DEVICES_DISABLED.TEXT' |
+                    translate
+                    }}
+                </div>
+            </md-radio-button>
+        </md-radio-group>
+        <div layout="row" layout-align="end center">
+            <md-button type="button" ng-click="vm.closeWizard()" class="md-raised md-secondary">
+                {{ 'ADMINCONSOLE.ACTIVATION.ACTION.CANCEL' | translate }}
+            </md-button>
+            <md-button type="button" ng-click="vm.prevStep()" class="md-raised md-secondary">
+                {{ 'ADMINCONSOLE.ACTIVATION.ACTION.BACK' | translate }}
+            </md-button>
+            <md-button type="submit" class="md-raised md-primary md-accent">
+                {{ 'ADMINCONSOLE.ACTIVATION.ACTION.CONTINUE' | translate }}
+            </md-button>
+        </div>
+    </form>
+</div>

--- a/eblocker-ui/src/settings/app/components/devices/discovery/devices-discovery.component.html
+++ b/eblocker-ui/src/settings/app/components/devices/discovery/devices-discovery.component.html
@@ -44,4 +44,20 @@
         </div>
 
     </div>
+
+    <div class="config-frame md-whiteframe-z1" layout="column">
+
+        <h3>{{'ADMINCONSOLE.DEVICES_DISCOVERY.AUTO_ENABLE_NEW_DEVICES.HEADER' | translate}}</h3>
+
+        <!-- SCAN DEVICES -->
+        <div layout="row" layout-align="start center">
+            <div>
+                <div layout="row">
+                     <md-switch md-theme="eBlockerThemeSwitch" ng-model="vm.isAutoEnableNewDevices" class="md-primary switch-word-break" ng-change="vm.setAutoEnableNewDevices()">
+            {{ vm.isAutoEnableNewDevices ? 'ADMINCONSOLE.DEVICES_DISCOVERY.AUTO_ENABLE_NEW_DEVICES.ENABLED' : 'ADMINCONSOLE.DEVICES_DISCOVERY.AUTO_ENABLE_NEW_DEVICES.DISABLED' | translate }}
+                    </md-switch>
+                </div>
+            </div>
+        </div>
+    </div>
 </div>

--- a/eblocker-ui/src/settings/app/components/devices/discovery/devices-discovery.component.js
+++ b/eblocker-ui/src/settings/app/components/devices/discovery/devices-discovery.component.js
@@ -36,9 +36,11 @@ function Controller(DeviceService, $interval) {
         vm.deviceScanningInterval = 10; // default
         getScanningInterval();
         isScanningAvailable();
+        isAutoEnableNewDevices();
     };
 
     vm.setScanningInterval = setScanningInterval;
+    vm.setAutoEnableNewDevices = setAutoEnableNewDevices;
     vm.scanDevices = scanDevices;
 
 
@@ -56,6 +58,16 @@ function Controller(DeviceService, $interval) {
         DeviceService.isScanningAvailable().then(function(response) {
             vm.scanningAvailable = response.data;
         });
+    }
+
+    function isAutoEnableNewDevices() {
+        DeviceService.isAutoEnableNewDevices().then(function(response) {
+            vm.isAutoEnableNewDevices = response.data;
+        });
+    }
+
+    function setAutoEnableNewDevices() {
+        DeviceService.setAutoEnableNewDevices(vm.isAutoEnableNewDevices);
     }
 
     function scanDevices() {

--- a/eblocker-ui/src/settings/app/service/devices/DeviceService.js
+++ b/eblocker-ui/src/settings/app/service/devices/DeviceService.js
@@ -21,6 +21,7 @@ export default function DeviceService($http, $q, DataCachingService) {
     const PATH_ALL = PATH + '/all/';
     const PATH_SCAN = PATH + '/scanningInterval';
     const PATH_SCAN_DEV = PATH + '/scan';
+    const PATH_AUTO_ENABLE_NEW_DEVICES = PATH + '/autoEnableNewDevices';
 
     let devicesCache;
 
@@ -112,6 +113,22 @@ export default function DeviceService($http, $q, DataCachingService) {
             return response;
         }, function(response) {
             $q.reject(response);
+        });
+    }
+
+    function isAutoEnableNewDevices() {
+        return $http.get(PATH_AUTO_ENABLE_NEW_DEVICES).then(function(response) {
+            return response;
+        }, function(response) {
+            $q.reject(response);
+        });
+    }
+
+    function setAutoEnableNewDevices(autoEnableNewDevices) {
+        return $http.post(PATH_AUTO_ENABLE_NEW_DEVICES, autoEnableNewDevices).then(function success(response) {
+            return response;
+        }, function error(response) {
+            return $q.reject(response);
         });
     }
 
@@ -218,6 +235,8 @@ export default function DeviceService($http, $q, DataCachingService) {
         update: update,
         scan: scan,
         isScanningAvailable: isScanningAvailable,
+        isAutoEnableNewDevices: isAutoEnableNewDevices,
+        setAutoEnableNewDevices: setAutoEnableNewDevices,
         invalidateCache: invalidateCache,
         setDisplayValues: setDisplayValues,
         resetDevice: resetDevice,


### PR DESCRIPTION
Users can set the mode during activation and later in the device settings.

As opposed to the previous PR, there is no modification of the dialog for changing the license.

This also includes a patch for #34 as the same part of the code is affected.

Unfortunately, I could not test it on a real device...