### PR TITLE
Bugfix: certificates issued for HTTPS error page should have max validity of 825 days

### DIFF
--- a/eblocker-icapserver/src/main/java/org/eblocker/server/common/ssl/EblockerCa.java
+++ b/eblocker-icapserver/src/main/java/org/eblocker/server/common/ssl/EblockerCa.java
@@ -24,10 +24,17 @@ import java.io.IOException;
 import java.security.KeyPair;
 import java.security.PrivateKey;
 import java.security.cert.X509Certificate;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
 import java.util.Date;
 import java.util.List;
 
 public class EblockerCa {
+    /*
+    Server certificates should have a maximum lifetime of 825 days:
+    https://cabforum.org/2017/03/17/ballot-193-825-day-certificate-lifetimes/
+     */
+    public static final int MAX_VALIDITY_SERVER_IN_DAYS = 825;
 
     private final CertificateAndKey certificateAndKey;
 
@@ -56,5 +63,18 @@ public class EblockerCa {
     private CertificateAndKey generateServerCertificate(CertificateAndKey requestAndKey, Date notValidAfter) throws CryptoException {
         X509Certificate certificate = PKI.generateTLSServerCertificate(requestAndKey.getCertificate(), null, null, notValidAfter, certificateAndKey);
         return new CertificateAndKey(certificate, requestAndKey.getKey());
+    }
+
+    /**
+     * Returns the end of the maximum lifetime of a server certificate.
+     * A server certificate can not be valid longer than the CA.
+     * In addition its lifetime can not be longer than 825 days.
+     * @return
+     */
+    public Date getServerNotValidAfter() {
+        Instant caNotAfter = certificateAndKey.getCertificate().getNotAfter().toInstant();
+        Instant maxNotAfter = Instant.now().plus(MAX_VALIDITY_SERVER_IN_DAYS, ChronoUnit.DAYS);
+        Instant result = maxNotAfter.isBefore(caNotAfter) ? maxNotAfter : caNotAfter;
+        return Date.from(result);
     }
 }

--- a/eblocker-icapserver/src/main/java/org/eblocker/server/common/ssl/GeneratingKeyManager.java
+++ b/eblocker-icapserver/src/main/java/org/eblocker/server/common/ssl/GeneratingKeyManager.java
@@ -123,7 +123,7 @@ public class GeneratingKeyManager extends X509ExtendedKeyManager {
     }
 
     private X509Certificate generateCertificate(Parameters parameters) throws CryptoException, IOException {
-        CertificateAndKey cak = eblockerCa.generateServerCertificate(parameters.names.get(0), keyPair, eblockerCa.getCertificate().getNotAfter(), parameters.names);
+        CertificateAndKey cak = eblockerCa.generateServerCertificate(parameters.names.get(0), keyPair, eblockerCa.getServerNotValidAfter(), parameters.names);
         return cak.getCertificate();
     }
 

--- a/eblocker-icapserver/src/test/java/org/eblocker/server/common/ssl/EblockerCaTest.java
+++ b/eblocker-icapserver/src/test/java/org/eblocker/server/common/ssl/EblockerCaTest.java
@@ -64,8 +64,8 @@ public class EblockerCaTest {
 
     @Test
     public void getServerNotValidAfter() {
-        Instant maxNotAfter = Instant.now().plus(825, ChronoUnit.DAYS);
         Instant serverNotAfter = eblockerCa.getServerNotValidAfter().toInstant();
+        Instant maxNotAfter = Instant.now().plus(825, ChronoUnit.DAYS);
         Assert.assertFalse(serverNotAfter.isAfter(maxNotAfter));
     }
 }

--- a/eblocker-icapserver/src/test/java/org/eblocker/server/common/ssl/EblockerCaTest.java
+++ b/eblocker-icapserver/src/test/java/org/eblocker/server/common/ssl/EblockerCaTest.java
@@ -21,8 +21,10 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
+import java.time.Instant;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
+import java.time.temporal.ChronoUnit;
 import java.util.Arrays;
 import java.util.Date;
 
@@ -60,4 +62,10 @@ public class EblockerCaTest {
         Assert.assertTrue(serverCertificateAndKey.getCertificate().getSubjectAlternativeNames().contains(Arrays.asList(7, "10.10.10.10")));
     }
 
+    @Test
+    public void getServerNotValidAfter() {
+        Instant maxNotAfter = Instant.now().plus(825, ChronoUnit.DAYS);
+        Instant serverNotAfter = eblockerCa.getServerNotValidAfter().toInstant();
+        Assert.assertFalse(serverNotAfter.isAfter(maxNotAfter));
+    }
 }

--- a/eblocker-icapserver/src/test/java/org/eblocker/server/common/ssl/GeneratingKeyManagerTest.java
+++ b/eblocker-icapserver/src/test/java/org/eblocker/server/common/ssl/GeneratingKeyManagerTest.java
@@ -37,6 +37,8 @@ import java.security.KeyPair;
 import java.security.Principal;
 import java.security.cert.CertificateParsingException;
 import java.security.cert.X509Certificate;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -169,6 +171,15 @@ public class GeneratingKeyManagerTest {
         Assert.assertEquals(2, chain[0].getSubjectAlternativeNames().size());
         Assert.assertTrue(chain[0].getSubjectAlternativeNames().contains(Arrays.asList(2, hostname)));
         Assert.assertTrue(chain[0].getSubjectAlternativeNames().contains(Arrays.asList(2, DEFAULT_NAME)));
+        assertExpiration(chain[0]);
+    }
+
+    private void assertExpiration(X509Certificate certificate) {
+        Instant notBefore = certificate.getNotBefore().toInstant();
+        Instant notAfter = certificate.getNotAfter().toInstant();
+        Instant notAfterCA = eblockerCa.getCertificate().getNotAfter().toInstant();
+        Assert.assertFalse(notAfter.isAfter(notAfterCA));
+        Assert.assertFalse(notAfter.isAfter(notBefore.plus(825, ChronoUnit.DAYS)));
     }
 
     private SSLSocket createMockSslSocket(String hostname, String ipAddress, int port) throws UnknownHostException {

--- a/eblocker-icapserver/src/test/java/org/eblocker/server/http/server/SSLContextHandlerTest.java
+++ b/eblocker-icapserver/src/test/java/org/eblocker/server/http/server/SSLContextHandlerTest.java
@@ -262,7 +262,7 @@ public class SSLContextHandlerTest {
         LocalDate usedCertNotBefore = LocalDateTime.ofInstant(usedKeyPair.getCertificate().getNotBefore().toInstant(), ZoneId.systemDefault()).toLocalDate();
         Assert.assertTrue(usedCertNotBefore.isEqual(LocalDate.now()));
         LocalDate usedCertNotAfter = LocalDateTime.ofInstant(usedKeyPair.getCertificate().getNotAfter().toInstant(), ZoneId.systemDefault()).toLocalDate();
-        Assert.assertTrue(usedCertNotAfter.isBefore(LocalDate.now().plusDays(SSLContextHandler.MAX_VALIDITY_IN_DAYS)));
+        Assert.assertFalse(usedCertNotAfter.isAfter(LocalDate.now().plusDays(EblockerCa.MAX_VALIDITY_SERVER_IN_DAYS)));
     }
 
     @Test


### PR DESCRIPTION
Move calculation of maximum validity for server certificates to EblockerCa.

Use it in GeneratingKeyManager, too.
