### PR TITLE
Ignore URL query parameters when searching for surrogate script

### DIFF
--- a/eblocker-icapserver/src/main/java/org/eblocker/server/icap/service/SurrogateService.java
+++ b/eblocker-icapserver/src/main/java/org/eblocker/server/icap/service/SurrogateService.java
@@ -44,7 +44,7 @@ public class SurrogateService {
 
     private Optional<String> surrogateForUrl(String url) {
         return urlToSurrogate.entrySet().stream()
-            .filter(e -> url.endsWith(e.getKey()))
+            .filter(e -> url.contains(e.getKey()))
             .findFirst()
             .map(Map.Entry::getValue);
     }

--- a/eblocker-icapserver/src/test/java/org/eblocker/server/icap/service/SurrogateServiceTest.java
+++ b/eblocker-icapserver/src/test/java/org/eblocker/server/icap/service/SurrogateServiceTest.java
@@ -36,6 +36,16 @@ public class SurrogateServiceTest {
     }
 
     @Test
+    public void testQueryMatch() {
+        assertTrue(surrogateService.surrogateForBlockedUrl("googletagmanager.com/gtm.js?id=GTM-W9MC85").isPresent());
+    }
+
+    @Test
+    public void testHandlesNullUrl() {
+        assertFalse(surrogateService.surrogateForBlockedUrl(null).isPresent());
+    }
+
+    @Test
     public void testAll() {
         surrogateService.getUrlToSurrogate().entrySet().forEach(e -> {
             assertTrue(surrogateService.surrogateForBlockedUrl(e.getKey()).isPresent());


### PR DESCRIPTION
gtm.js seems to carry an URL query parameter quite often: ignore it, when searching for the surrogate
