### PR TITLE
Device view as tab

### DIFF
--- a/eblocker-ui/src/locale/lang-settings-de.json
+++ b/eblocker-ui/src/locale/lang-settings-de.json
@@ -417,6 +417,10 @@
                     "LABEL_CLOAKING_OFF_LABEL" : "Nicht tarnen",
                     "TAB_LABEL" : "Anonymisierung"
                 },
+                "DEVICE" : {
+                    "TAB_LABEL" : "Geräte",
+                    "HEADING" : "Gerätedetails"
+                },
                 "FILTERS" : {
                     "MALWARE" : {
                         "LABEL" : "Malware & Phishing Blocker",

--- a/eblocker-ui/src/locale/lang-settings-de.json
+++ b/eblocker-ui/src/locale/lang-settings-de.json
@@ -418,7 +418,7 @@
                     "TAB_LABEL" : "Anonymisierung"
                 },
                 "DEVICE" : {
-                    "TAB_LABEL" : "Geräte",
+                    "TAB_LABEL" : "Gerät",
                     "HEADING" : "Gerätedetails"
                 },
                 "FILTERS" : {

--- a/eblocker-ui/src/locale/lang-settings-en.json
+++ b/eblocker-ui/src/locale/lang-settings-en.json
@@ -417,6 +417,10 @@
                     "LABEL_CLOAKING_OFF_LABEL" : "No cloaking",
                     "TAB_LABEL" : "Anonymization"
                 },
+                "DEVICE" : {
+                    "TAB_LABEL" : "Device",
+                    "HEADING" : "Details for device"
+                },
                 "FILTERS" : {
                     "MALWARE" : {
                         "LABEL" : "Malware Blocker",
@@ -458,7 +462,8 @@
                     "LABEL_VENDOR" : "Vendor",
                     "TOOLTIP" : {
                         "EDIT_DEVICE" : "Edit device name."
-                    }
+                    },
+                    "TAB_LABEL" : "Device"
                 },
                 "HEADING" : "Details for device",
                 "HTTPS" : {

--- a/eblocker-ui/src/settings/app/components/devices/list/devices-details-anon.component.html
+++ b/eblocker-ui/src/settings/app/components/devices/list/devices-details-anon.component.html
@@ -1,4 +1,4 @@
-<div style="padding-top: 16px;">
+<div style="padding-top: 8px;">
     <div layout="column" layout-padding>
 
         <div layout="column" layout-align="center start">

--- a/eblocker-ui/src/settings/app/components/devices/list/devices-details-device.component.html
+++ b/eblocker-ui/src/settings/app/components/devices/list/devices-details-device.component.html
@@ -1,0 +1,94 @@
+<div layout="column" layout-align="start start" style="padding-top: 8px;" layout-padding>
+
+        <div layout="column" layout-align="start start">
+        <!-- Device details-ip address, mac address, enabled, disabled -->
+                <div layout="row" layout-align="start center">
+                    <h4>{{'ADMINCONSOLE.DEVICES_LIST.DETAILS.DEVICE.HEADING' | translate}}
+                    </h4>
+                </div>
+            <!--containing flex box for device details ip, mac, vendor-->
+            <div flex-gt-md="95" style="height: 100%;" layout="column">
+                    <div style="padding-top: 8px;">
+                        <eb-label-container label="{{'ADMINCONSOLE.DEVICES_LIST.DETAILS.GENERAL.LABEL_IP' | translate}}" config="vm.deviceIp"></eb-label-container>
+                    </div>
+                    <div>
+                        <eb-label-container label="{{'ADMINCONSOLE.DEVICES_LIST.DETAILS.GENERAL.LABEL_MAC' | translate}}" config="vm.deviceMac"></eb-label-container>
+                    </div>
+                    <div>
+                        <eb-label-container label="{{'ADMINCONSOLE.DEVICES_LIST.DETAILS.GENERAL.LABEL_VENDOR' | translate}}" config="vm.deviceVendor"></eb-label-container>
+                    </div>
+            </div>
+        </div>
+                <!-- **** Edit -->
+                <div layout="row" layout-align="start center" style="width: 100%;">
+                    <div flex-gt-xs="33" flex-lg="25" flex-gt-lg="25" style="width: 100%;">
+                        <eb-label-container is-edit="vm.editable(vm.device)" edit-callback="vm.editName($event, vm.device)"
+                                            style="margin-bottom: 15px;" label="{{'ADMINCONSOLE.DEVICES_LIST.DETAILS.GENERAL.LABEL_NAME' | translate}}" config="vm.deviceName"></eb-label-container>
+                    </div>
+                </div>
+
+                <md-divider style="width: 100%;"></md-divider>
+                <div ng-if="!vm.device.isGateway && !vm.device.isEblocker" layout="column" layout-align="start start">
+                    <div>
+                        <md-switch md-theme="eBlockerThemeSwitch"
+                                   layout="row" layout-align="center center" layout-padding
+                                   class="md-primary switch-word-break"
+                                   ng-model="vm.device.pausedOrEnabled"
+                                   ng-change="vm.onChangeEnabled(vm.device)"
+                                   ng-disabled="vm.isUpdatingDevice">
+                            {{ vm.device.pausedOrEnabled ? 'ADMINCONSOLE.DEVICES_LIST.DETAILS.GENERAL.LABEL_ENABLED_EBLOCKER' : 'ADMINCONSOLE.DEVICES_LIST.DETAILS.GENERAL.LABEL_DISABLED_EBLOCKER' | translate }}
+                        </md-switch>
+                    </div>
+
+                    <!-- workaround: otherwise switch labels overlap on small devices -->
+                    <div hide-gt-xs style="margin-top: 35px;"></div>
+
+                    <div ng-if="vm.pausingAllowed !== false" layout="row" layout-align="start center">
+                        <md-switch md-theme="eBlockerThemeSwitch" class="md-primary switch-word-break"
+                                   layout="row" layout-align="center center" layout-padding
+                                   ng-model="vm.device.paused"
+                                   ng-change="vm.onChangePaused(vm.device)"
+                                   ng-disabled="!vm.device.pausedOrEnabled || vm.pauseStatusPending || vm.isUpdatingDevice">
+                            <span ng-hide="vm.device.paused" translate="ADMINCONSOLE.DEVICES_LIST.DETAILS.GENERAL.LABEL_NOT_PAUSE_EBLOCKER"></span>
+                            <span ng-show="vm.device.paused && vm.pauseRemaining > 0">{{'ADMINCONSOLE.DEVICES_LIST.DETAILS.GENERAL.LABEL_PAUSE_EBLOCKER_COUNTDOWN' | translate:{min: vm.getPauseMinutes(), sec: vm.getPauseSeconds()} }}</span>
+                            <span ng-show="vm.device.paused && (vm.pauseRemaining === undefined || vm.pauseRemaining <= 0)">{{'ADMINCONSOLE.DEVICES_LIST.DETAILS.GENERAL.LABEL_PAUSE_EBLOCKER' | translate }}</span>
+                        </md-switch>
+                    </div>
+
+                    <div ng-if="vm.device.pausedOrEnabled && vm.pausingAllowed === false" layout="row" layout-align="start center" layout-padding>
+                        <span translate="ADMINCONSOLE.DEVICES_LIST.DETAILS.GENERAL.LABEL_PAUSE_NOT_ALLOWED"></span>
+                    </div>
+                    
+                    <div ng-if="!vm.isUpdatingDevice && !vm.spinnerDelay && !vm.device.isGateway && !vm.device.isEblocker" style="padding-top: 26px;">
+                    </div>
+
+                    <div ng-if="vm.isUpdatingDevice || vm.spinnerDelay"
+                        layout="row" layout="start center"
+                        style="padding-left: 8px;">
+                        <div>
+                        <md-progress-circular md-mode="indeterminate" md-diameter="26"></md-progress-circular>
+                        </div>
+                        <span style="padding-left: 16px;" translate="ADMINCONSOLE.DEVICES_LIST.DETAILS.GENERAL.LABEL_DEVICE_UPDATING"></span>
+                    </div>
+
+                    <!-- workaround: otherwise switch labels overlap on small devices -->
+                    <div hide-gt-xs style="margin-top: 20px;" ng-if="vm.dhcpActive"></div>
+
+                    <!-- Fixed IP Switch (DHCP) -->
+                    <div ng-if="vm.dhcpActive">
+                        <md-switch md-theme="eBlockerThemeSwitch" layout-padding layout="row" layout-align="start center" ng-model="vm.device.ipAddressFixed" class="md-primary switch-word-break" ng-change="vm.onChange(vm.device)">
+                            {{ vm.device.ipAddressFixed ? 'ADMINCONSOLE.DEVICES_LIST.DETAILS.GENERAL.LABEL_IP_ADDRESS_FIXED' : 'ADMINCONSOLE.DEVICES_LIST.DETAILS.GENERAL.LABEL_IP_ADDRESS_NOT_FIXED' | translate }}
+                        </md-switch>
+                    </div>
+                    <!-- Reset button -->
+                    <md-divider style="width: 100%;"></md-divider>
+                    <div style="padding-top: 26px;">
+                        <md-button class="md-raised eb-delete-button"
+                                    ng-click="vm.onResetDevice(vm.device)"
+                                    aria-label="{{ 'ADMINCONSOLE.DEVICES_LIST.DETAILS.GENERAL.LABEL_RESET_DEVICE' | translate }}">
+                            {{'ADMINCONSOLE.DEVICES_LIST.DETAILS.GENERAL.LABEL_RESET_DEVICE' | translate}}
+                        </md-button>
+                    </div>
+               <!-- </div> -->
+    </div>
+</div>

--- a/eblocker-ui/src/settings/app/components/devices/list/devices-details-device.component.html
+++ b/eblocker-ui/src/settings/app/components/devices/list/devices-details-device.component.html
@@ -9,7 +9,7 @@
         <!--containing flex box for device details ip, mac, vendor-->
         <div  style="height: 100%; width: 100%;" layout="row" layout-xs="column">
                 <!-- <div style="padding-top: 8px;"> -->
-            <div layout="row" layout-xs="column" layout-align="start start"  style= "paddint-top: 16px; width: 100%;">
+            <div layout="row" layout-xs="column" layout-align="start start"  style= "padding-top: 16px; width: 100%;">
                 <div flex-gt-xs="33" flex-lg="25" flex-gt-lg="25" style="width: 100%;">
                     <eb-label-container label="{{'ADMINCONSOLE.DEVICES_LIST.DETAILS.GENERAL.LABEL_IP' | translate}}" config="vm.deviceIp"></eb-label-container>
                 </div>
@@ -77,7 +77,7 @@
         </div>
 
         <!-- workaround: otherwise switch labels overlap on small devices -->
-        <div hide-gt-xs style="margin-top: 20px;" ></div>
+        <div hide-gt-xs style="margin-top: 10px;" ></div>
 
         <!-- Fixed IP Switch (DHCP) -->
         <div ng-if="vm.dhcpActive">

--- a/eblocker-ui/src/settings/app/components/devices/list/devices-details-device.component.html
+++ b/eblocker-ui/src/settings/app/components/devices/list/devices-details-device.component.html
@@ -1,94 +1,98 @@
-<div layout="column" layout-align="start start" style="padding-top: 8px;" layout-padding>
-
-        <div layout="column" layout-align="start start">
-        <!-- Device details-ip address, mac address, enabled, disabled -->
-                <div layout="row" layout-align="start center">
-                    <h4>{{'ADMINCONSOLE.DEVICES_LIST.DETAILS.DEVICE.HEADING' | translate}}
-                    </h4>
+<div layout="column" style="padding-top: 8px;" layout-padding>
+    <!-- Page for device details-ip address, mac address, enabled, disabled -->
+    <div layout="column"  layout-align="center start" >
+    
+            <div layout="row" layout-align="start center" style="width: 100%;">
+                <h4>{{'ADMINCONSOLE.DEVICES_LIST.DETAILS.DEVICE.HEADING' | translate}}
+                </h4>
+            </div>
+        <!--containing flex box for device details ip, mac, vendor-->
+        <div  style="height: 100%; width: 100%;" layout="row" layout-xs="column">
+                <!-- <div style="padding-top: 8px;"> -->
+            <div layout="row" layout-xs="column" layout-align="start start"  style= "paddint-top: 16px; width: 100%;">
+                <div flex-gt-xs="33" flex-lg="25" flex-gt-lg="25" style="width: 100%;">
+                    <eb-label-container label="{{'ADMINCONSOLE.DEVICES_LIST.DETAILS.GENERAL.LABEL_IP' | translate}}" config="vm.deviceIp"></eb-label-container>
                 </div>
-            <!--containing flex box for device details ip, mac, vendor-->
-            <div flex-gt-md="95" style="height: 100%;" layout="column">
-                    <div style="padding-top: 8px;">
-                        <eb-label-container label="{{'ADMINCONSOLE.DEVICES_LIST.DETAILS.GENERAL.LABEL_IP' | translate}}" config="vm.deviceIp"></eb-label-container>
-                    </div>
-                    <div>
-                        <eb-label-container label="{{'ADMINCONSOLE.DEVICES_LIST.DETAILS.GENERAL.LABEL_MAC' | translate}}" config="vm.deviceMac"></eb-label-container>
-                    </div>
-                    <div>
-                        <eb-label-container label="{{'ADMINCONSOLE.DEVICES_LIST.DETAILS.GENERAL.LABEL_VENDOR' | translate}}" config="vm.deviceVendor"></eb-label-container>
-                    </div>
+                <div flex-gt-xs="33" flex-lg="25" flex-gt-lg="25" style="width: 100%;">
+                    <eb-label-container label="{{'ADMINCONSOLE.DEVICES_LIST.DETAILS.GENERAL.LABEL_MAC' | translate}}" config="vm.deviceMac"></eb-label-container>
+                </div>
+                <div flex-gt-xs="33" flex-lg="25" flex-gt-lg="25" style="width: 100%;">
+                    <eb-label-container label="{{'ADMINCONSOLE.DEVICES_LIST.DETAILS.GENERAL.LABEL_VENDOR' | translate}}" config="vm.deviceVendor"></eb-label-container>
+                </div>
+            </div>    
+        </div>
+        <!-- **** Edit -->
+        <div layout="row" layout-align="start center" style="width: 100%;">
+            <!-- <div flex-gt-xs="33" flex-lg="25" flex-gt-lg="25" style="width: 100%;"> -->
+                <div >
+                <eb-label-container is-edit="vm.editable(vm.device)" edit-callback="vm.editName($event, vm.device)"
+                                    style="margin-bottom: 15px;" label="{{'ADMINCONSOLE.DEVICES_LIST.DETAILS.GENERAL.LABEL_NAME' | translate}}" config="vm.deviceName"></eb-label-container>
             </div>
         </div>
-                <!-- **** Edit -->
-                <div layout="row" layout-align="start center" style="width: 100%;">
-                    <div flex-gt-xs="33" flex-lg="25" flex-gt-lg="25" style="width: 100%;">
-                        <eb-label-container is-edit="vm.editable(vm.device)" edit-callback="vm.editName($event, vm.device)"
-                                            style="margin-bottom: 15px;" label="{{'ADMINCONSOLE.DEVICES_LIST.DETAILS.GENERAL.LABEL_NAME' | translate}}" config="vm.deviceName"></eb-label-container>
-                    </div>
-                </div>
+    </div>
 
-                <md-divider style="width: 100%;"></md-divider>
-                <div ng-if="!vm.device.isGateway && !vm.device.isEblocker" layout="column" layout-align="start start">
-                    <div>
-                        <md-switch md-theme="eBlockerThemeSwitch"
-                                   layout="row" layout-align="center center" layout-padding
-                                   class="md-primary switch-word-break"
-                                   ng-model="vm.device.pausedOrEnabled"
-                                   ng-change="vm.onChangeEnabled(vm.device)"
-                                   ng-disabled="vm.isUpdatingDevice">
-                            {{ vm.device.pausedOrEnabled ? 'ADMINCONSOLE.DEVICES_LIST.DETAILS.GENERAL.LABEL_ENABLED_EBLOCKER' : 'ADMINCONSOLE.DEVICES_LIST.DETAILS.GENERAL.LABEL_DISABLED_EBLOCKER' | translate }}
-                        </md-switch>
-                    </div>
+    <md-divider ng-if="!vm.device.isGateway && !vm.device.isEblocker" style="width: 100%;"></md-divider>
+    
+    <div ng-if="!vm.device.isGateway && !vm.device.isEblocker" layout="column" layout-align="start start">
+        <div>
+            <md-switch md-theme="eBlockerThemeSwitch"
+                        layout="row" layout-align="center center" layout-padding
+                        class="md-primary switch-word-break"
+                        ng-model="vm.device.pausedOrEnabled"
+                        ng-change="vm.onChangeEnabled(vm.device)"
+                        ng-disabled="vm.isUpdatingDevice">
+                {{ vm.device.pausedOrEnabled ? 'ADMINCONSOLE.DEVICES_LIST.DETAILS.GENERAL.LABEL_ENABLED_EBLOCKER' : 'ADMINCONSOLE.DEVICES_LIST.DETAILS.GENERAL.LABEL_DISABLED_EBLOCKER' | translate }}
+            </md-switch>
+        </div>
 
-                    <!-- workaround: otherwise switch labels overlap on small devices -->
-                    <div hide-gt-xs style="margin-top: 35px;"></div>
+        <!-- workaround: otherwise switch labels overlap on small devices -->
+        <div hide-gt-xs style="margin-top: 35px;"></div>
 
-                    <div ng-if="vm.pausingAllowed !== false" layout="row" layout-align="start center">
-                        <md-switch md-theme="eBlockerThemeSwitch" class="md-primary switch-word-break"
-                                   layout="row" layout-align="center center" layout-padding
-                                   ng-model="vm.device.paused"
-                                   ng-change="vm.onChangePaused(vm.device)"
-                                   ng-disabled="!vm.device.pausedOrEnabled || vm.pauseStatusPending || vm.isUpdatingDevice">
-                            <span ng-hide="vm.device.paused" translate="ADMINCONSOLE.DEVICES_LIST.DETAILS.GENERAL.LABEL_NOT_PAUSE_EBLOCKER"></span>
-                            <span ng-show="vm.device.paused && vm.pauseRemaining > 0">{{'ADMINCONSOLE.DEVICES_LIST.DETAILS.GENERAL.LABEL_PAUSE_EBLOCKER_COUNTDOWN' | translate:{min: vm.getPauseMinutes(), sec: vm.getPauseSeconds()} }}</span>
-                            <span ng-show="vm.device.paused && (vm.pauseRemaining === undefined || vm.pauseRemaining <= 0)">{{'ADMINCONSOLE.DEVICES_LIST.DETAILS.GENERAL.LABEL_PAUSE_EBLOCKER' | translate }}</span>
-                        </md-switch>
-                    </div>
+        <div ng-if="vm.pausingAllowed !== false" layout="row" layout-align="start center">
+            <md-switch md-theme="eBlockerThemeSwitch" class="md-primary switch-word-break"
+                        layout="row" layout-align="center center" layout-padding
+                        ng-model="vm.device.paused"
+                        ng-change="vm.onChangePaused(vm.device)"
+                        ng-disabled="!vm.device.pausedOrEnabled || vm.pauseStatusPending || vm.isUpdatingDevice">
+                <span ng-hide="vm.device.paused" translate="ADMINCONSOLE.DEVICES_LIST.DETAILS.GENERAL.LABEL_NOT_PAUSE_EBLOCKER"></span>
+                <span ng-show="vm.device.paused && vm.pauseRemaining > 0">{{'ADMINCONSOLE.DEVICES_LIST.DETAILS.GENERAL.LABEL_PAUSE_EBLOCKER_COUNTDOWN' | translate:{min: vm.getPauseMinutes(), sec: vm.getPauseSeconds()} }}</span>
+                <span ng-show="vm.device.paused && (vm.pauseRemaining === undefined || vm.pauseRemaining <= 0)">{{'ADMINCONSOLE.DEVICES_LIST.DETAILS.GENERAL.LABEL_PAUSE_EBLOCKER' | translate }}</span>
+            </md-switch>
+        </div>
 
-                    <div ng-if="vm.device.pausedOrEnabled && vm.pausingAllowed === false" layout="row" layout-align="start center" layout-padding>
-                        <span translate="ADMINCONSOLE.DEVICES_LIST.DETAILS.GENERAL.LABEL_PAUSE_NOT_ALLOWED"></span>
-                    </div>
-                    
-                    <div ng-if="!vm.isUpdatingDevice && !vm.spinnerDelay && !vm.device.isGateway && !vm.device.isEblocker" style="padding-top: 26px;">
-                    </div>
+        <div ng-if="vm.device.pausedOrEnabled && vm.pausingAllowed === false" layout="row" layout-align="start center" layout-padding>
+            <span translate="ADMINCONSOLE.DEVICES_LIST.DETAILS.GENERAL.LABEL_PAUSE_NOT_ALLOWED"></span>
+        </div>
+        
+        <div ng-if="!vm.isUpdatingDevice && !vm.spinnerDelay && !vm.device.isGateway && !vm.device.isEblocker" style="padding-top: 26px;">
+        </div>
 
-                    <div ng-if="vm.isUpdatingDevice || vm.spinnerDelay"
-                        layout="row" layout="start center"
-                        style="padding-left: 8px;">
-                        <div>
-                        <md-progress-circular md-mode="indeterminate" md-diameter="26"></md-progress-circular>
-                        </div>
-                        <span style="padding-left: 16px;" translate="ADMINCONSOLE.DEVICES_LIST.DETAILS.GENERAL.LABEL_DEVICE_UPDATING"></span>
-                    </div>
+        <div ng-if="vm.isUpdatingDevice || vm.spinnerDelay"
+            layout="row" layout="start center"
+            style="padding-left: 8px;">
+            <div>
+                <md-progress-circular md-mode="indeterminate" md-diameter="26"></md-progress-circular>
+            </div>
+            <span style="padding-left: 16px;" translate="ADMINCONSOLE.DEVICES_LIST.DETAILS.GENERAL.LABEL_DEVICE_UPDATING"></span>
+        </div>
 
-                    <!-- workaround: otherwise switch labels overlap on small devices -->
-                    <div hide-gt-xs style="margin-top: 20px;" ng-if="vm.dhcpActive"></div>
+        <!-- workaround: otherwise switch labels overlap on small devices -->
+        <div hide-gt-xs style="margin-top: 20px;" ></div>
 
-                    <!-- Fixed IP Switch (DHCP) -->
-                    <div ng-if="vm.dhcpActive">
-                        <md-switch md-theme="eBlockerThemeSwitch" layout-padding layout="row" layout-align="start center" ng-model="vm.device.ipAddressFixed" class="md-primary switch-word-break" ng-change="vm.onChange(vm.device)">
-                            {{ vm.device.ipAddressFixed ? 'ADMINCONSOLE.DEVICES_LIST.DETAILS.GENERAL.LABEL_IP_ADDRESS_FIXED' : 'ADMINCONSOLE.DEVICES_LIST.DETAILS.GENERAL.LABEL_IP_ADDRESS_NOT_FIXED' | translate }}
-                        </md-switch>
-                    </div>
-                    <!-- Reset button -->
-                    <md-divider style="width: 100%;"></md-divider>
-                    <div style="padding-top: 26px;">
-                        <md-button class="md-raised eb-delete-button"
-                                    ng-click="vm.onResetDevice(vm.device)"
-                                    aria-label="{{ 'ADMINCONSOLE.DEVICES_LIST.DETAILS.GENERAL.LABEL_RESET_DEVICE' | translate }}">
-                            {{'ADMINCONSOLE.DEVICES_LIST.DETAILS.GENERAL.LABEL_RESET_DEVICE' | translate}}
-                        </md-button>
-                    </div>
-               <!-- </div> -->
+        <!-- Fixed IP Switch (DHCP) -->
+        <div ng-if="vm.dhcpActive">
+            <md-switch md-theme="eBlockerThemeSwitch" layout-padding layout="row" layout-align="start center" ng-model="vm.device.ipAddressFixed" class="md-primary switch-word-break" ng-change="vm.onChange(vm.device)">
+                {{ vm.device.ipAddressFixed ? 'ADMINCONSOLE.DEVICES_LIST.DETAILS.GENERAL.LABEL_IP_ADDRESS_FIXED' : 'ADMINCONSOLE.DEVICES_LIST.DETAILS.GENERAL.LABEL_IP_ADDRESS_NOT_FIXED' | translate }}
+            </md-switch>
+        </div>
+        <!-- Reset button -->
+        <md-divider style="width: 100%; margin-top: 12px;"></md-divider>
+        <div style="padding-top: 26px;">
+            <md-button class="md-raised eb-delete-button"
+                        ng-click="vm.onResetDevice(vm.device)"
+                        aria-label="{{ 'ADMINCONSOLE.DEVICES_LIST.DETAILS.GENERAL.LABEL_RESET_DEVICE' | translate }}">
+                {{'ADMINCONSOLE.DEVICES_LIST.DETAILS.GENERAL.LABEL_RESET_DEVICE' | translate}}
+            </md-button>
+        </div>
     </div>
 </div>

--- a/eblocker-ui/src/settings/app/components/devices/list/devices-details.component.html
+++ b/eblocker-ui/src/settings/app/components/devices/list/devices-details.component.html
@@ -21,176 +21,86 @@
 
         <!-- content -->
         <div flex-gt-md="95" style="height: 100%;" layout="column">
-
-            <div class="config-frame md-whiteframe-z1" layout="column">
-                <div>
-                    <h3 style="margin: 0;" class="eb-table-details-view">
-                        {{'ADMINCONSOLE.DEVICES_LIST.DETAILS.HEADING' | translate}}
-                    </h3>
-                </div>
-
-                <div layout="row" layout-xs="column" layout-align="start start" style="padding-top: 16px; width: 100%;">
-                    <div flex-gt-xs="33" flex-lg="25" flex-gt-lg="25" style="width: 100%;">
-                        <eb-label-container label="{{'ADMINCONSOLE.DEVICES_LIST.DETAILS.GENERAL.LABEL_IP' | translate}}" config="vm.deviceIp"></eb-label-container>
-                    </div>
-                    <div flex-gt-xs="33" flex-lg="25" flex-gt-lg="25" style="width: 100%;">
-                        <eb-label-container label="{{'ADMINCONSOLE.DEVICES_LIST.DETAILS.GENERAL.LABEL_MAC' | translate}}" config="vm.deviceMac"></eb-label-container>
-                    </div>
-                    <div flex-gt-xs="33" flex-lg="25" flex-gt-lg="25" style="width: 100%;">
-                        <eb-label-container label="{{'ADMINCONSOLE.DEVICES_LIST.DETAILS.GENERAL.LABEL_VENDOR' | translate}}" config="vm.deviceVendor"></eb-label-container>
-                    </div>
-                </div>
-
-                <!-- **** Edit -->
-                <div layout="row" layout-align="start center" style="width: 100%;">
-                    <div flex-gt-xs="33" flex-lg="25" flex-gt-lg="25" style="width: 100%;">
-                        <eb-label-container is-edit="vm.editable(vm.device)" edit-callback="vm.editName($event, vm.device)"
-                                            style="margin-bottom: 15px;" label="{{'ADMINCONSOLE.DEVICES_LIST.DETAILS.GENERAL.LABEL_NAME' | translate}}" config="vm.deviceName"></eb-label-container>
-                    </div>
-                </div>
-            </div>
-
-
-            <!-- Main switch -->
-            <div class="config-frame md-whiteframe-z1" layout="column">
+            <!-- Main switch / Added conditional for displaying frame on eblocker or gateway-->
+            <div ng-if="vm.device.isGateway || vm.device.isEblocker" class="config-frame md-whiteframe-z1" layout="column">
                 <div ng-if="vm.device.isGateway" style="padding-left: 16px;">
                     <p>{{ 'ADMINCONSOLE.DEVICES_LIST.DETAILS.GENERAL.LABEL_IS_GATEWAY' | translate }}</p>
                 </div>
                 <div ng-if="vm.device.isEblocker" style="padding-left: 16px;">
                     <p>{{ 'ADMINCONSOLE.DEVICES_LIST.DETAILS.GENERAL.LABEL_IS_EBLOCKER' | translate}}</p>
                 </div>
-
-                <div ng-if="!vm.device.isGateway && !vm.device.isEblocker" layout="column" layout-align="start start">
-                    <div>
-                        <md-switch md-theme="eBlockerThemeSwitch"
-                                   layout="row" layout-align="center center" layout-padding
-                                   class="md-primary switch-word-break"
-                                   ng-model="vm.device.pausedOrEnabled"
-                                   ng-change="vm.onChangeEnabled(vm.device)"
-                                   ng-disabled="vm.isUpdatingDevice">
-                            {{ vm.device.pausedOrEnabled ? 'ADMINCONSOLE.DEVICES_LIST.DETAILS.GENERAL.LABEL_ENABLED_EBLOCKER' : 'ADMINCONSOLE.DEVICES_LIST.DETAILS.GENERAL.LABEL_DISABLED_EBLOCKER' | translate }}
-                        </md-switch>
-                    </div>
-                </div>
-
-                <!-- workaround: otherwise switch labels overlap on small devices -->
-                <div hide-gt-xs style="margin-top: 20px;"></div>
-
-                <div ng-if="!vm.device.isGateway && !vm.device.isEblocker" layout="column" layout-align="start start">
-                    <div ng-if="vm.pausingAllowed !== false" layout="row" layout-align="start center">
-                        <md-switch md-theme="eBlockerThemeSwitch" class="md-primary switch-word-break"
-                                   layout="row" layout-align="center center" layout-padding
-                                   ng-model="vm.device.paused"
-                                   ng-change="vm.onChangePaused(vm.device)"
-                                   ng-disabled="!vm.device.pausedOrEnabled || vm.pauseStatusPending || vm.isUpdatingDevice">
-                            <span ng-hide="vm.device.paused" translate="ADMINCONSOLE.DEVICES_LIST.DETAILS.GENERAL.LABEL_NOT_PAUSE_EBLOCKER"></span>
-                            <span ng-show="vm.device.paused && vm.pauseRemaining > 0">{{'ADMINCONSOLE.DEVICES_LIST.DETAILS.GENERAL.LABEL_PAUSE_EBLOCKER_COUNTDOWN' | translate:{min: vm.getPauseMinutes(), sec: vm.getPauseSeconds()} }}</span>
-                            <span ng-show="vm.device.paused && (vm.pauseRemaining === undefined || vm.pauseRemaining <= 0)">{{'ADMINCONSOLE.DEVICES_LIST.DETAILS.GENERAL.LABEL_PAUSE_EBLOCKER' | translate }}</span>
-                        </md-switch>
-                    </div>
-
-                    <div ng-if="vm.device.pausedOrEnabled && vm.pausingAllowed === false" layout="row" layout-align="start center" layout-padding>
-                        <span translate="ADMINCONSOLE.DEVICES_LIST.DETAILS.GENERAL.LABEL_PAUSE_NOT_ALLOWED"></span>
-                    </div>
-                </div>
-
-                <div ng-if="!vm.isUpdatingDevice && !vm.spinnerDelay && !vm.device.isGateway && !vm.device.isEblocker" style="padding-top: 26px;">
-                </div>
-
-                <div ng-if="vm.isUpdatingDevice || vm.spinnerDelay"
-                     layout="row" layout="start center"
-                     style="padding-left: 8px;">
-                    <div>
-                        <md-progress-circular md-mode="indeterminate" md-diameter="26"></md-progress-circular>
-                    </div>
-                    <span style="padding-left: 16px;" translate="ADMINCONSOLE.DEVICES_LIST.DETAILS.GENERAL.LABEL_DEVICE_UPDATING"></span>
-                </div>
-
-                <!-- workaround: otherwise switch labels overlap on small devices -->
-                <div hide-gt-xs style="margin-top: 20px;" ng-if="vm.dhcpActive"></div>
-
-
-                <!-- Fixed IP Switch (DHCP) -->
-                <div ng-if="vm.dhcpActive">
-                    <md-switch md-theme="eBlockerThemeSwitch" layout-padding layout="row" layout-align="start center" ng-model="vm.device.ipAddressFixed" class="md-primary switch-word-break" ng-change="vm.onChange(vm.device)">
-                        {{ vm.device.ipAddressFixed ? 'ADMINCONSOLE.DEVICES_LIST.DETAILS.GENERAL.LABEL_IP_ADDRESS_FIXED' : 'ADMINCONSOLE.DEVICES_LIST.DETAILS.GENERAL.LABEL_IP_ADDRESS_NOT_FIXED' | translate }}
-                    </md-switch>
-                </div>
             </div>
-
-            <div class="config-frame md-whiteframe-z1"
-                 layout="column" ng-if="!vm.device.isGateway && !vm.device.isEblocker">
-                <!-- Reset button -->
-                <div>
-                    <md-button class="md-raised eb-delete-button"
-                               ng-click="vm.onResetDevice(vm.device)"
-                               aria-label="{{ 'ADMINCONSOLE.DEVICES_LIST.DETAILS.GENERAL.LABEL_RESET_DEVICE' | translate }}">
-                        {{'ADMINCONSOLE.DEVICES_LIST.DETAILS.GENERAL.LABEL_RESET_DEVICE' | translate}}
-                    </md-button>
-                </div>
-            </div>
-
-            <div class="config-frame md-whiteframe-z1" ng-if="!vm.device.isGateway && !vm.device.isEblocker && vm.device.pausedOrEnabled">
+            <!-- Removed '&& vm.device.pausedOrEnabled' from ng-if to display device details in tabulated form when vm.device.paused enabled-->
+            <div class="config-frame md-whiteframe-z1" ng-if="!vm.device.isGateway && !vm.device.isEblocker">
                 <md-tabs md-border-bottom
                          md-swipe-content
                          md-dynamic-height>
 
-                    <!-- USER -->
-                    <md-tab ng-if="vm.hasFeature('FAM')">
-                        <md-tab-label>{{ 'ADMINCONSOLE.DEVICES_LIST.DETAILS.USERS.TAB_LABEL' | translate }}</md-tab-label>
-                        <md-tab-body>
-                            <ng-include src="'app/components/devices/list/devices-details-users.component.html'"></ng-include>
-                        </md-tab-body>
-                    </md-tab>
-
-                    <!-- ANONYMIZATION -->
-                    <md-tab ng-disabled="!vm.hasFeature('BAS')">
-                        <md-tab-label>{{ 'ADMINCONSOLE.DEVICES_LIST.DETAILS.ANON.TAB_LABEL' | translate }}</md-tab-label>
-                        <md-tab-body>
-                            <ng-include src="'app/components/devices/list/devices-details-anon.component.html'"></ng-include>
-                        </md-tab-body>
-                    </md-tab>
-
-                    <!-- MOBILE -->
-                    <md-tab ng-disabled="!vm.vpnHomeStatus.isRunning || !vm.hasFeature('PRO')">
-                        <md-tab-label>{{ 'ADMINCONSOLE.DEVICES_LIST.DETAILS.MOBILE.TAB_LABEL' | translate }}</md-tab-label>
-                        <md-tab-body>
-                            <ng-include src="'app/components/devices/list/devices-details-mobile.component.html'"></ng-include>
-                        </md-tab-body>
-                    </md-tab>
-
-                    <!-- FILTERS -->
-                    <md-tab ng-disabled="!vm.hasFeature('PRO')">
-                        <md-tab-label>{{ 'ADMINCONSOLE.DEVICES_LIST.DETAILS.FILTERS.TAB_LABEL' | translate }}</md-tab-label>
-                        <md-tab-body>
-                            <ng-include src="'app/components/devices/list/devices-details-filters.component.html'"></ng-include>
-                        </md-tab-body>
-                    </md-tab>
-
-                    <!-- HTTPS -->
-                    <md-tab ng-disabled="!vm.hasFeature('PRO')" ng-if="vm.sslGloballyEnabled">
-                        <md-tab-label>{{ 'ADMINCONSOLE.DEVICES_LIST.DETAILS.HTTPS.TAB_LABEL' | translate }}</md-tab-label>
-                        <md-tab-body>
-                            <ng-include src="'app/components/devices/list/devices-details-https.component.html'"></ng-include>
-                        </md-tab-body>
-                    </md-tab>
-
-                    <!-- ICON / CONTROLBAR -->
+                    <!-- Tab for  DEVICE details -->
                     <md-tab>
-                        <md-tab-label>{{ 'ADMINCONSOLE.DEVICES_LIST.DETAILS.ICON.TAB_LABEL' | translate }}</md-tab-label>
+                        <md-tab-label>{{ 'ADMINCONSOLE.DEVICES_LIST.DETAILS.DEVICE.TAB_LABEL' | translate }}</md-tab-label>
                         <md-tab-body>
-                            <ng-include src="'app/components/devices/list/devices-details-icon.component.html'"></ng-include>
+                            <ng-include src="'app/components/devices/list/devices-details-device.component.html'"></ng-include>
                         </md-tab-body>
                     </md-tab>
 
-                    <!-- MESSAGES -->
-                    <md-tab ng-disabled="!vm.hasFeature('BAS')">
-                        <md-tab-label>{{ 'ADMINCONSOLE.DEVICES_LIST.DETAILS.MESSAGES.TAB_LABEL' | translate }}</md-tab-label>
-                        <md-tab-body>
-                            <ng-include src="'app/components/devices/list/devices-details-messages.component.html'"></ng-include>
-                        </md-tab-body>
-                    </md-tab>
+                    <!-- USER -->
+                    <div ng-if="vm.device.pausedOrEnabled">
+                        <md-tab ng-if="vm.hasFeature('FAM')">
+                            <md-tab-label>{{ 'ADMINCONSOLE.DEVICES_LIST.DETAILS.USERS.TAB_LABEL' | translate }}</md-tab-label>
+                            <md-tab-body>
+                                <ng-include src="'app/components/devices/list/devices-details-users.component.html'"></ng-include>
+                            </md-tab-body>
+                        </md-tab>
 
+                        <!-- ANONYMIZATION -->
+                            <md-tab ng-disabled="!vm.hasFeature('BAS')">
+                                <md-tab-label>{{ 'ADMINCONSOLE.DEVICES_LIST.DETAILS.ANON.TAB_LABEL' | translate }}</md-tab-label>
+                                <md-tab-body>
+                                    <ng-include src="'app/components/devices/list/devices-details-anon.component.html'"></ng-include>
+                                </md-tab-body>
+                            </md-tab>
+
+                        <!-- MOBILE -->
+                            <md-tab ng-disabled="!vm.vpnHomeStatus.isRunning || !vm.hasFeature('PRO')">
+                                <md-tab-label>{{ 'ADMINCONSOLE.DEVICES_LIST.DETAILS.MOBILE.TAB_LABEL' | translate }}</md-tab-label>
+                                <md-tab-body>
+                                    <ng-include src="'app/components/devices/list/devices-details-mobile.component.html'"></ng-include>
+                                </md-tab-body>
+                            </md-tab>
+
+                        <!-- FILTERS -->
+                        <md-tab ng-disabled="!vm.hasFeature('PRO')">
+                            <md-tab-label>{{ 'ADMINCONSOLE.DEVICES_LIST.DETAILS.FILTERS.TAB_LABEL' | translate }}</md-tab-label>
+                            <md-tab-body>
+                                <ng-include src="'app/components/devices/list/devices-details-filters.component.html'"></ng-include>
+                            </md-tab-body>
+                        </md-tab>
+
+                        <!-- HTTPS -->
+                        <md-tab ng-disabled="!vm.hasFeature('PRO')" ng-if="vm.sslGloballyEnabled">
+                            <md-tab-label>{{ 'ADMINCONSOLE.DEVICES_LIST.DETAILS.HTTPS.TAB_LABEL' | translate }}</md-tab-label>
+                            <md-tab-body>
+                                <ng-include src="'app/components/devices/list/devices-details-https.component.html'"></ng-include>
+                            </md-tab-body>
+                        </md-tab>
+
+                        <!-- ICON / CONTROLBAR -->
+                        <md-tab>
+                            <md-tab-label>{{ 'ADMINCONSOLE.DEVICES_LIST.DETAILS.ICON.TAB_LABEL' | translate }}</md-tab-label>
+                            <md-tab-body>
+                                <ng-include src="'app/components/devices/list/devices-details-icon.component.html'"></ng-include>
+                            </md-tab-body>
+                        </md-tab>
+
+                        <!-- MESSAGES -->
+                        <md-tab ng-disabled="!vm.hasFeature('BAS')">
+                            <md-tab-label>{{ 'ADMINCONSOLE.DEVICES_LIST.DETAILS.MESSAGES.TAB_LABEL' | translate }}</md-tab-label>
+                            <md-tab-body>
+                                <ng-include src="'app/components/devices/list/devices-details-messages.component.html'"></ng-include>
+                            </md-tab-body>
+                        </md-tab>
+                    </div>
                 </md-tabs>
             </div>
         </div>

--- a/eblocker-ui/src/settings/app/components/devices/list/devices-details.component.html
+++ b/eblocker-ui/src/settings/app/components/devices/list/devices-details.component.html
@@ -21,7 +21,7 @@
 
         <!-- content -->
         <div flex-gt-md="95" style="height: 100%;" layout="column">
-            <!-- Main switch / Added conditional for displaying frame on eblocker or gateway-->
+            <!-- Added conditional for displaying frame on eblocker or gateway-->
             <div ng-if="vm.device.isGateway || vm.device.isEblocker" class="config-frame md-whiteframe-z1" layout="column">
                 <div ng-if="vm.device.isGateway" style="padding-left: 16px;">
                     <p>{{ 'ADMINCONSOLE.DEVICES_LIST.DETAILS.GENERAL.LABEL_IS_GATEWAY' | translate }}</p>
@@ -31,7 +31,7 @@
                 </div>
             </div>
             <!-- Removed '&& vm.device.pausedOrEnabled' from ng-if to display device details in tabulated form when vm.device.paused enabled-->
-            <div class="config-frame md-whiteframe-z1" ng-if="!vm.device.isGateway && !vm.device.isEblocker">
+            <div class="config-frame md-whiteframe-z1" >
                 <md-tabs md-border-bottom
                          md-swipe-content
                          md-dynamic-height>
@@ -43,9 +43,9 @@
                             <ng-include src="'app/components/devices/list/devices-details-device.component.html'"></ng-include>
                         </md-tab-body>
                     </md-tab>
-
+                    <!-- Added conditional to hide tabs when eblocker not enabled for device -->
+                    <div ng-if="vm.device.pausedOrEnabled && !vm.device.isGateway && !vm.device.isEblocker">
                     <!-- USER -->
-                    <div ng-if="vm.device.pausedOrEnabled">
                         <md-tab ng-if="vm.hasFeature('FAM')">
                             <md-tab-label>{{ 'ADMINCONSOLE.DEVICES_LIST.DETAILS.USERS.TAB_LABEL' | translate }}</md-tab-label>
                             <md-tab-body>

--- a/eblocker-ui/src/settings/app/components/devices/list/devices-details.component.html
+++ b/eblocker-ui/src/settings/app/components/devices/list/devices-details.component.html
@@ -5,7 +5,6 @@
             <div layout="row" layout-align="start center" layout-align-xs="center center" style="width: 100%;">
                 <eb-back-to-table state="{{vm.backState}}" params="vm.stateParams"></eb-back-to-table>
             </div>
-
             <div layout="row" layout-align="end center" layout-align-xs="center center" style="width: 100%;">
                 <eb-details-paginator table-data="vm.tableData"
                                       tooltip-property="displayName"
@@ -31,6 +30,10 @@
                 </div>
             </div>
             <!-- Removed '&& vm.device.pausedOrEnabled' from ng-if to display device details in tabulated form when vm.device.paused enabled-->
+            <div ng-if="!vm.device.isGateway && !vm.device.isEblocker">
+                <h4>{{ vm.device.name }}
+                </h4>
+            </div>
             <div class="config-frame md-whiteframe-z1" >
                 <md-tabs md-border-bottom
                          md-swipe-content


### PR DESCRIPTION
Changes to the Admin GUI. Presents device details as a 'tab' instead of standalone.
Tested working within dev env and on installed PI. 

Implements request as noted in https://github.com/orgs/eblocker/projects/2#card-50844898