### PR TITLE
Feature/ata limit time range for addition and treat cert error special

### DIFF
--- a/eblocker-icapserver/src/main/java/org/eblocker/server/http/service/AutoTrustAppService.java
+++ b/eblocker-icapserver/src/main/java/org/eblocker/server/http/service/AutoTrustAppService.java
@@ -8,21 +8,28 @@ import org.eblocker.server.common.squid.FailedConnection;
 import org.eblocker.server.common.squid.SquidWarningService;
 import org.eblocker.server.common.startup.SubSystemService;
 import org.eblocker.server.http.ssl.AppWhitelistModule;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.time.Duration;
 import java.time.Instant;
 import java.util.Collections;
 import java.util.Comparator;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
+
+import static java.util.function.Predicate.not;
 
 @SubSystemService(value = SubSystem.SERVICES)
 public class AutoTrustAppService implements SquidWarningService.FailedConnectionsListener {
 
+    private static final Logger log = LoggerFactory.getLogger(AutoTrustAppService.class);
+
     public static final Duration MAX_RANGE_BETWEEN_TWO_FAILED_CONECTIONS = Duration.ofMinutes(30);
+    public static final String CERT_UNTRUSTED_ERROR = "X509_V_ERR_CERT_UNTRUSTED";
     private final AppModuleService appModuleService;
     private final DomainBlockingService domainBlockingService;
     private final Map<String, Instant> pendingDomains = new ConcurrentHashMap<>();
@@ -43,41 +50,74 @@ public class AutoTrustAppService implements SquidWarningService.FailedConnection
     }
 
     private void updateFromAllFailedConnections(List<FailedConnection> failedConnections) {
-        List<FailedConnection> sortedFailed = failedConnections.stream()
-                .sorted(Comparator.comparing(FailedConnection::getLastOccurrence))
-                .collect(Collectors.toList());
         AppWhitelistModule autoTrustAppModule = getAutoTrustAppModule();
         List<String> existingWhitelistedDomains = autoTrustAppModule.getWhitelistedDomains();
 
-        List<SSLWhitelistUrl> newWhiteListUrls = new LinkedList<>();
-        sortedFailed.forEach(fc -> fc.getDomains().forEach(domain -> {
-            if (pendingDomains.containsKey(domain)) {
-                handleAlreadyPending(domain, fc.getLastOccurrence(), newWhiteListUrls);
-            } else {
-                handleNotPending(domain, fc.getLastOccurrence(), existingWhitelistedDomains);
-            }
-        }));
+        List<SSLWhitelistUrl> newWhiteListUrls =
+                failedConnections.stream()
+                        .sorted(Comparator.comparing(FailedConnection::getLastOccurrence))
+                        .flatMap(fc ->
+                                fc.getDomains().stream()
+                                        .filter(not(existingWhitelistedDomains::contains))
+                                        .map(domain -> processDomain(domain, fc))
+                                        .flatMap(Optional::stream))
+                        .distinct()
+                        .map(domain -> new SSLWhitelistUrl("", domain))
+                        .collect(Collectors.toList());
 
         if (!newWhiteListUrls.isEmpty()) {
             appModuleService.addDomainsToModule(newWhiteListUrls, autoTrustAppModule.getId());
         }
     }
 
-    private void handleAlreadyPending(String domain, Instant lastSeen, List<SSLWhitelistUrl> newWhiteListUrls) {
-        Instant pendingSeen = pendingDomains.get(domain);
-        if (lastSeen.isAfter(pendingSeen) && lastSeen.minus(MAX_RANGE_BETWEEN_TWO_FAILED_CONECTIONS).isBefore(pendingSeen)) {
-            pendingDomains.remove(domain);
-            newWhiteListUrls.add(new SSLWhitelistUrl("", domain));
+    private Optional<String> processDomain(String domain, FailedConnection fc) {
+        log.debug("Processing failed connection " + fc.getDomains() + " " + fc.getErrors() + " " + fc.getLastOccurrence());
+        if (hasCertUntrustedError(fc)) {
+            return processCertificateError(domain);
+        } else if (pendingDomains.containsKey(domain)) {
+            return processAlreadyPending(domain, fc.getLastOccurrence());
         } else {
-            // overwrite with newer occurrence
-            pendingDomains.put(domain, lastSeen);
+            return processNotPending(domain, fc.getLastOccurrence());
         }
     }
 
-    private void handleNotPending(String domain, Instant lastSeen, List<String> existingWhitelistedDomains) {
-        if (!existingWhitelistedDomains.contains(domain) && !domainBlockingService.isDomainBlockedByMalwareAdsTrackersFilters(domain).isBlocked()) {
-            pendingDomains.put(domain, lastSeen);
+    private boolean hasCertUntrustedError(FailedConnection fc) {
+        return fc.getErrors().stream().anyMatch(s -> s.contains(CERT_UNTRUSTED_ERROR));
+    }
+
+    private Optional<String> processCertificateError(String domain) {
+        if (isDomainEligibleForAutoTrustApp(domain)) {
+            return Optional.of(domain);
+        } else {
+            return Optional.empty();
         }
+    }
+
+    private Optional<String> processAlreadyPending(String domain, Instant lastSeen) {
+        Instant pendingSeen = pendingDomains.get(domain);
+        log.debug("pendingSeen for " + domain + " is " + pendingSeen);
+        if (lastSeen.isAfter(pendingSeen) && lastSeen.minus(MAX_RANGE_BETWEEN_TWO_FAILED_CONECTIONS).isBefore(pendingSeen)) {
+            log.debug("Adding " + domain + " to AutoTrustApp");
+            pendingDomains.remove(domain);
+            return Optional.of(domain);
+        } else {
+            // overwrite with newer occurrence
+            pendingDomains.put(domain, lastSeen);
+            log.debug("Overwriting FC in pendingDomains");
+            return Optional.empty();
+        }
+    }
+
+    private Optional<String> processNotPending(String domain, Instant lastSeen) {
+        if (isDomainEligibleForAutoTrustApp(domain)) {
+            pendingDomains.put(domain, lastSeen);
+            log.debug("Adding FC to pendingDomains");
+        }
+        return Optional.empty();
+    }
+
+    private boolean isDomainEligibleForAutoTrustApp(String domain) {
+        return !domainBlockingService.isDomainBlockedByMalwareAdsTrackersFilters(domain).isBlocked();
     }
 
     @Override

--- a/eblocker-icapserver/src/main/java/org/eblocker/server/http/service/AutoTrustAppService.java
+++ b/eblocker-icapserver/src/main/java/org/eblocker/server/http/service/AutoTrustAppService.java
@@ -9,16 +9,20 @@ import org.eblocker.server.common.squid.SquidWarningService;
 import org.eblocker.server.common.startup.SubSystemService;
 import org.eblocker.server.http.ssl.AppWhitelistModule;
 
+import java.time.Duration;
 import java.time.Instant;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.Collectors;
 
 @SubSystemService(value = SubSystem.SERVICES)
 public class AutoTrustAppService implements SquidWarningService.FailedConnectionsListener {
 
+    public static final Duration MAX_RANGE_BETWEEN_TWO_FAILED_CONECTIONS = Duration.ofMinutes(30);
     private final AppModuleService appModuleService;
     private final DomainBlockingService domainBlockingService;
     private final Map<String, Instant> pendingDomains = new ConcurrentHashMap<>();
@@ -39,11 +43,14 @@ public class AutoTrustAppService implements SquidWarningService.FailedConnection
     }
 
     private void updateFromAllFailedConnections(List<FailedConnection> failedConnections) {
+        List<FailedConnection> sortedFailed = failedConnections.stream()
+                .sorted(Comparator.comparing(FailedConnection::getLastOccurrence))
+                .collect(Collectors.toList());
         AppWhitelistModule autoTrustAppModule = getAutoTrustAppModule();
         List<String> existingWhitelistedDomains = autoTrustAppModule.getWhitelistedDomains();
 
         List<SSLWhitelistUrl> newWhiteListUrls = new LinkedList<>();
-        failedConnections.forEach(fc -> fc.getDomains().forEach(domain -> {
+        sortedFailed.forEach(fc -> fc.getDomains().forEach(domain -> {
             if (pendingDomains.containsKey(domain)) {
                 handleAlreadyPending(domain, fc.getLastOccurrence(), newWhiteListUrls);
             } else {
@@ -57,9 +64,13 @@ public class AutoTrustAppService implements SquidWarningService.FailedConnection
     }
 
     private void handleAlreadyPending(String domain, Instant lastSeen, List<SSLWhitelistUrl> newWhiteListUrls) {
-        if (pendingDomains.get(domain).isBefore(lastSeen)) {
+        Instant pendingSeen = pendingDomains.get(domain);
+        if (lastSeen.isAfter(pendingSeen) && lastSeen.minus(MAX_RANGE_BETWEEN_TWO_FAILED_CONECTIONS).isBefore(pendingSeen)) {
             pendingDomains.remove(domain);
             newWhiteListUrls.add(new SSLWhitelistUrl("", domain));
+        } else {
+            // overwrite with newer occurrence
+            pendingDomains.put(domain, lastSeen);
         }
     }
 


### PR DESCRIPTION
Require two failed connections to happen between 30 minutes.
If the error message is X509_V_ERR_CERT_UNTRUSTED, put the domain onto the list right away, as this really seems to happen for certificate pinning only (seen for Signal messenger).