### PR TITLE
Improve AutoTrustApp quite a bit:

### DIFF
--- a/eblocker-icapserver/src/main/java/org/eblocker/server/http/service/AutoTrustAppService.java
+++ b/eblocker-icapserver/src/main/java/org/eblocker/server/http/service/AutoTrustAppService.java
@@ -2,6 +2,7 @@ package org.eblocker.server.http.service;
 
 import com.google.inject.Inject;
 import org.eblocker.server.common.blacklist.DomainBlockingService;
+import org.eblocker.server.common.data.Device;
 import org.eblocker.server.common.data.SSLWhitelistUrl;
 import org.eblocker.server.common.data.systemstatus.SubSystem;
 import org.eblocker.server.common.squid.FailedConnection;
@@ -13,33 +14,112 @@ import org.slf4j.LoggerFactory;
 
 import java.time.Duration;
 import java.time.Instant;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
 
 import static java.util.function.Predicate.not;
 
+/**
+ * Possible improvements:
+ * * Never whitelist a domain name for which a pattern blocker URL exists
+ * ____+ prevents whitelisting when a popular tracker URL leads to random connection errors
+ * ____- if the domain of a blocker URL is rather generic (i.e. amazon.com), ATA will never whitelist it
+ * ____? Check the logs how many whitelisting of tracker domains this could prevent
+ * * Immediately whitelist (after tracking check) for all cert related errors
+ * ___+ grep "Processing " /var/log/eblocker/eblocker-system.log* | grep -v "No error" | grep -v "reset by peer" | grep -v "Broken pipe" | cut -d "[" -f 5 | cut -d "]" -f 1 | sort | uniq
+ * ____+ faster whitelisting in case of certificate pinning
+ * ____+ Tracker check is still in place, so this does not affect handling of known evil domains
+ * ____+ Danger is adding
+ * ____+ (hopefully) no additional whitelisting of favorite websites as they don't produce these kinds of errors
+ * ____+ (hopefully) no additional whitelisting of tracking domains as they don't produce these kinds of errors and the tracking check would still happen
+ * <p>
+ * crtvd:27:X509_V_ERR_CERT_UNTRUSTED
+ * ssl:1:error:14094412:SSL routines:ssl3_read_bytes:sslv3 alert bad certificate
+ * ssl:1:error:14094416:SSL routines:ssl3_read_bytes:sslv3 alert certificate unknown
+ * ssl:1:error:14094418:SSL routines:ssl3_read_bytes:tlsv1 alert unknown ca
+ * ssl:1:error:14209102:SSL routines:tls_early_post_process_client_hello:unsupported protocol
+ * ssl:6:error:00000000:lib(0):func(0):reason(0)
+ * <p>
+ * ____- there seem to be cases where cert-related errors stem from browsing (e.g. datenschutz-zwecklos.de for benne).
+ * ____? Check in how many cases this would speed up whitelisting for certificate pinning
+ * ____? Check in how many cases this would put favorite websites on the list IN ADDITION
+ * <p>
+ * * * When recording successful SSL connections, also record the device
+ * ____+ Spotify seems to work fine on iOS but complains about dealer.spotify.com on macOS
+ * ____- Blows up the recoding of successful domains
+ * ____- Device A cannot benefit from the successful SSL connections on device B
+ *
+ * * * Why does My own DTBL work even though it is enabled???
+ */
 @SubSystemService(value = SubSystem.SERVICES)
 public class AutoTrustAppService implements SquidWarningService.FailedConnectionsListener {
+
+    enum KnownError {
+        SELF_SIGNED_CERT_IN_CHAIN("crtvd:19:X509_V_ERR_SELF_SIGNED_CERT_IN_CHAIN", true),
+        CERT_UNTRUSTED("crtvd:27:X509_V_ERR_CERT_UNTRUSTED", true), // TODO: also seen for 5thmarket.info, which is a tracker, and for bzz.ch (web only)
+        BAD_CERTIFICATE("ssl:1:error:14094412:SSL routines:ssl3_read_bytes:sslv3 alert bad certificate", true), // TODO seen for lookaside.facebook.com, i.instagram.com, graph.instagram.com, graph.facebook.com so is this really a isCertError?
+        CERTIFICATE_UNKNOWN("ssl:1:error:14094416:SSL routines:ssl3_read_bytes:sslv3 alert certificate unknown", true),
+        UNKNOWN_CA("ssl:1:error:14094418:SSL routines:ssl3_read_bytes:tlsv1 alert unknown ca", true),
+        UNSUPPORTED_PROTOCOL("ssl:1:error:14209102:SSL routines:tls_early_post_process_client_hello:unsupported protocol", true),
+        CONNECTION_RESET("io:104:(104) Connection reset by peer", false),
+        NO_ERROR("io:0:(0) No error.", false),
+        BROKEN_PIPE("io:32:(32) Broken pipe", false),
+        SOME_UNKNOWN_SSL("ssl:6:error:00000000:lib(0):func(0):reason(0)", false), // Don't know what this means
+        DOMAIN_MISMATCH_ERROR("crtvd:-1:SQUID_X509_V_ERR_DOMAIN_MISMATCH", false);
+        private final String message;
+        private final boolean isCertError;
+
+        KnownError(String message, boolean isCertError) {
+            this.message = message;
+            this.isCertError = isCertError;
+        }
+
+        private static final List<KnownError> certErrors =
+                Arrays.stream(KnownError.values()).filter(ke -> ke.isCertError).collect(Collectors.toList());
+
+        private boolean matchesError(String error) {
+            return error.contains(message);
+        }
+
+        public static boolean hasCertError(FailedConnection fc) {
+            return fc.getErrors().stream()
+                    .anyMatch(err -> certErrors.stream().anyMatch(ce -> ce.matchesError(err)));
+        }
+
+        public static boolean hasUnknownError(FailedConnection fc) {
+            return !fc.getErrors().stream()
+                    .allMatch(err -> Arrays.stream(KnownError.values()).anyMatch(ke -> ke.matchesError(err)));
+        }
+
+        public String getMessage() {
+            return message;
+        }
+    }
 
     private static final Logger log = LoggerFactory.getLogger(AutoTrustAppService.class);
 
     public static final Duration MAX_RANGE_BETWEEN_TWO_FAILED_CONECTIONS = Duration.ofMinutes(30);
-    public static final String CERT_UNTRUSTED_ERROR = "X509_V_ERR_CERT_UNTRUSTED";
     private final AppModuleService appModuleService;
     private final DomainBlockingService domainBlockingService;
+    private final DeviceService deviceService;
     private final Map<String, Instant> pendingDomains = new ConcurrentHashMap<>();
+    private final SuccessfulSSLDomains successfulSSLDomains = new SuccessfulSSLDomains(1000, 100, 0.001);
 
     @Inject
     public AutoTrustAppService(SquidWarningService squidWarningService,
                                AppModuleService appModuleService,
-                               DomainBlockingService domainBlockingService) {
+                               DomainBlockingService domainBlockingService,
+                               DeviceService deviceService) {
         this.appModuleService = appModuleService;
         this.domainBlockingService = domainBlockingService;
+        this.deviceService = deviceService;
 
         squidWarningService.addListener(this);
     }
@@ -56,12 +136,18 @@ public class AutoTrustAppService implements SquidWarningService.FailedConnection
         List<SSLWhitelistUrl> newWhiteListUrls =
                 failedConnections.stream()
                         .sorted(Comparator.comparing(FailedConnection::getLastOccurrence))
+                        .peek(fc -> {
+                            if (KnownError.hasUnknownError(fc)) {
+                                log.warn("Unknown error in failed connection: " + fc.getErrors());
+                            }
+                        })
                         .flatMap(fc ->
                                 fc.getDomains().stream()
                                         .filter(not(existingWhitelistedDomains::contains))
                                         .map(domain -> processDomain(domain, fc))
                                         .flatMap(Optional::stream))
                         .distinct()
+                        .peek(domain -> log.debug("Whitelisting " + domain))
                         .map(domain -> new SSLWhitelistUrl("", domain))
                         .collect(Collectors.toList());
 
@@ -71,53 +157,107 @@ public class AutoTrustAppService implements SquidWarningService.FailedConnection
     }
 
     private Optional<String> processDomain(String domain, FailedConnection fc) {
-        log.debug("Processing failed connection " + fc.getDomains() + " " + fc.getErrors() + " " + fc.getLastOccurrence());
-        if (hasCertUntrustedError(fc)) {
+        logFailedConnection(fc);
+        if (!happendOnSSLDevice(fc)) {
+            return Optional.empty();
+        } else if (!isDomainEligibleForAutoTrustApp(domain)) {
+            log.trace("Not eligible for AutoTrustApp: " + domain);
+            pendingDomains.remove(domain); // border case: just became not eligible
+            return Optional.empty();
+        } else if (hasNonCertificateError(fc)) {
+            log.debug("Skipping. No cert error " + domain);
+            // also remove from pending domains?
+            return Optional.empty();
+        } else if (hasObviousRootCertificateProblemError(fc)) {
+            log.debug("hasObviousRootCertificateProblemError" + domain);
             return processCertificateError(domain);
-        } else if (pendingDomains.containsKey(domain)) {
+        } else if (isPending(domain)) {
             return processAlreadyPending(domain, fc.getLastOccurrence());
         } else {
             return processNotPending(domain, fc.getLastOccurrence());
         }
     }
 
-    private boolean hasCertUntrustedError(FailedConnection fc) {
-        return fc.getErrors().stream().anyMatch(s -> s.contains(CERT_UNTRUSTED_ERROR));
+    private void logFailedConnection(FailedConnection fc) {
+        if (Instant.now().minus(Duration.ofMinutes(61)).isBefore(fc.getLastOccurrence())) {
+            log.debug("Processing failed connection " + fc.getDomains() + " " + fc.getErrors() + " " + fc.getLastOccurrence() + " " + fc.getDeviceIds().stream().map(deviceService::getDeviceById).filter(Objects::nonNull).collect(Collectors.toList()));
+        } else {
+            log.trace("Processing failed connection " + fc.getDomains() + " " + fc.getErrors() + " " + fc.getLastOccurrence() + " " + fc.getDeviceIds().stream().map(deviceService::getDeviceById).filter(Objects::nonNull).collect(Collectors.toList()));
+        }
+    }
+
+    private boolean happendOnSSLDevice(FailedConnection fc) {
+        return fc.getDeviceIds().stream()
+                .map(deviceService::getDeviceById)
+                .filter(Objects::nonNull)
+                .filter(Device::isEnabled)
+                .anyMatch(Device::isSslEnabled);
+    }
+
+    private boolean hasNonCertificateError(FailedConnection fc) {
+        return fc.getErrors().stream()
+                .anyMatch(KnownError.DOMAIN_MISMATCH_ERROR::matchesError);
+        // maybe even automatically remove all subdomains from the list as it can cause various problems? (see armakeup.com and https://community.letsencrypt.org/t/high-server-load-and-longer-time-to-produce-certificates/67760/29)
+    }
+
+    private boolean hasObviousRootCertificateProblemError(FailedConnection fc) {
+        return KnownError.hasCertError(fc);
+    }
+
+    private boolean isPending(String domain) {
+        return pendingDomains.containsKey(domain);
     }
 
     private Optional<String> processCertificateError(String domain) {
-        if (isDomainEligibleForAutoTrustApp(domain)) {
-            return Optional.of(domain);
-        } else {
-            return Optional.empty();
-        }
+        return Optional.of(domain);
     }
 
     private Optional<String> processAlreadyPending(String domain, Instant lastSeen) {
         Instant pendingSeen = pendingDomains.get(domain);
-        log.debug("pendingSeen for " + domain + " is " + pendingSeen);
-        if (lastSeen.isAfter(pendingSeen) && lastSeen.minus(MAX_RANGE_BETWEEN_TWO_FAILED_CONECTIONS).isBefore(pendingSeen)) {
-            log.debug("Adding " + domain + " to AutoTrustApp");
-            pendingDomains.remove(domain);
-            return Optional.of(domain);
+        if (lastSeen.isAfter(pendingSeen)) {
+            if (lastSeen.minus(MAX_RANGE_BETWEEN_TWO_FAILED_CONECTIONS).isBefore(pendingSeen)) {
+                pendingDomains.remove(domain);
+                return Optional.of(domain);
+            } else {
+                // overwrite with newer occurrence
+                pendingDomains.put(domain, lastSeen);
+                log.debug("Overwriting " + domain + " in pendingDomains with newer occurence");
+                return Optional.empty();
+            }
         } else {
-            // overwrite with newer occurrence
-            pendingDomains.put(domain, lastSeen);
-            log.debug("Overwriting FC in pendingDomains");
             return Optional.empty();
         }
     }
 
     private Optional<String> processNotPending(String domain, Instant lastSeen) {
-        if (isDomainEligibleForAutoTrustApp(domain)) {
+        if (Instant.now().minus(MAX_RANGE_BETWEEN_TWO_FAILED_CONECTIONS).isBefore(lastSeen)) {
             pendingDomains.put(domain, lastSeen);
-            log.debug("Adding FC to pendingDomains");
+            log.debug("Adding " + domain + " to pendingDomains");
+        } else {
+            log.trace("FailedConnection too old to add domain " + domain);
         }
         return Optional.empty();
     }
 
     private boolean isDomainEligibleForAutoTrustApp(String domain) {
-        return !domainBlockingService.isDomainBlockedByMalwareAdsTrackersFilters(domain).isBlocked();
+        return !isBlocked(domain) &&
+                !isDomainAlreadySucessful(domain);
+    }
+
+    private boolean isBlocked(String domain) {
+        boolean blocked = domainBlockingService.isDomainBlockedByMalwareAdsTrackersFilters(domain).isBlocked();
+        if (blocked) {
+            log.trace("Domain is blocked: " + domain);
+        }
+        return blocked;
+    }
+
+    private boolean isDomainAlreadySucessful(String domain) {
+        boolean domainAlreadySucessful = successfulSSLDomains.isDomainAlreadySucessful(domain);
+        if (domainAlreadySucessful) {
+            log.debug("Domain already successful: " + domain);
+        }
+        return domainAlreadySucessful;
     }
 
     @Override
@@ -125,9 +265,14 @@ public class AutoTrustAppService implements SquidWarningService.FailedConnection
         AppWhitelistModule autoTrustAppModule = getAutoTrustAppModule();
         autoTrustAppModule.setWhitelistedDomains(Collections.emptyList());
         appModuleService.update(autoTrustAppModule, autoTrustAppModule.getId());
+        pendingDomains.clear();
     }
 
     private AppWhitelistModule getAutoTrustAppModule() {
         return appModuleService.getAutoSslAppModule();
+    }
+
+    public void recordSuccessfulSSL(String domain) {
+        successfulSSLDomains.recordDomain(domain);
     }
 }

--- a/eblocker-icapserver/src/main/java/org/eblocker/server/http/service/SuccessfulSSLDomains.java
+++ b/eblocker-icapserver/src/main/java/org/eblocker/server/http/service/SuccessfulSSLDomains.java
@@ -1,0 +1,64 @@
+package org.eblocker.server.http.service;
+
+import com.google.common.base.Charsets;
+import com.google.common.hash.BloomFilter;
+import com.google.common.hash.Funnels;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+class SuccessfulSSLDomains {
+    private static final Logger log = LoggerFactory.getLogger(SuccessfulSSLDomains.class);
+
+    private BloomFilter<String> activeBloomFilter;
+    private int sizeOfActive;
+    private BloomFilter<String> standbyBloomFilter;
+    private int sizeOfStandby;
+    private final int maxSize;
+    private final int overlap;
+    private final double falsePositiveProbability;
+
+    SuccessfulSSLDomains(int maxSize, int overlap, double falsePositiveProbability) {
+        if (overlap >= maxSize) {
+            throw new RuntimeException("Overlap must be smaller than maxSize");
+        }
+        this.maxSize = maxSize;
+        this.overlap = overlap;
+        this.falsePositiveProbability = falsePositiveProbability;
+        activeBloomFilter = createBloomFilter();
+        standbyBloomFilter = createBloomFilter();
+    }
+
+    public boolean isDomainAlreadySucessful(String domain) {
+        return activeBloomFilter.mightContain(domain);
+    }
+
+    public int size() {
+        return sizeOfActive;
+    }
+
+    public void recordDomain(String domain) {
+        boolean filterChanged = activeBloomFilter.put(domain);
+        if (filterChanged) {
+            updateForNewDomain(domain);
+            log.debug("Recorded new already successful domain " + domain + " Size is now " + sizeOfActive);
+        }
+    }
+
+    private synchronized void updateForNewDomain(String domain) {
+        sizeOfActive += 1;
+        if (maxSize - sizeOfActive < overlap) {
+            standbyBloomFilter.put(domain);
+            sizeOfStandby += 1;
+        }
+        if (sizeOfActive >= maxSize) {
+            activeBloomFilter = standbyBloomFilter;
+            sizeOfActive = sizeOfStandby;
+            standbyBloomFilter = createBloomFilter();
+            sizeOfStandby = 0;
+        }
+    }
+
+    private BloomFilter<String> createBloomFilter() {
+        return BloomFilter.create(Funnels.stringFunnel(Charsets.US_ASCII), maxSize, falsePositiveProbability);
+    }
+}

--- a/eblocker-icapserver/src/main/java/org/eblocker/server/icap/transaction/TransactionProcessorsModule.java
+++ b/eblocker-icapserver/src/main/java/org/eblocker/server/icap/transaction/TransactionProcessorsModule.java
@@ -44,6 +44,7 @@ import org.eblocker.server.icap.transaction.processor.SessionProcessor;
 import org.eblocker.server.icap.transaction.processor.SetBaseUrlProcessor;
 import org.eblocker.server.icap.transaction.processor.SetDntHeaderProcessor;
 import org.eblocker.server.icap.transaction.processor.SetInjectionsProcessor;
+import org.eblocker.server.icap.transaction.processor.SuccessfulSSLDetector;
 import org.eblocker.server.icap.transaction.processor.TrackingBlockerProcessor;
 import org.eblocker.server.icap.transaction.processor.UserAgentSpoofProcessor;
 import org.eblocker.server.icap.transaction.processor.WebRTCBlocker;
@@ -77,8 +78,10 @@ public class TransactionProcessorsModule extends AbstractModule {
                                                            SetBaseUrlProcessor setBaseUrlProcessor,
                                                            SetDntHeaderProcessor setDntHeaderProcessor,
                                                            TrackingBlockerProcessor trackingBlockerProcessor,
-                                                           UserAgentSpoofProcessor userAgentSpoofProcessor) {
+                                                           UserAgentSpoofProcessor userAgentSpoofProcessor,
+                                                           SuccessfulSSLDetector successfulSSLDetector) {
         return Arrays.asList(
+                successfulSSLDetector,
                 sessionProcessor,
                 ignoreEBlockerProcessor,
                 bpjmFilterProcessor,
@@ -117,8 +120,10 @@ public class TransactionProcessorsModule extends AbstractModule {
                                                             SetBaseUrlProcessor setBaseUrlProcessor,
                                                             SetInjectionsProcessor setInjectionsProcessor,
                                                             WebRTCBlocker webRTCBlocker,
-                                                            YoutubeAdBlocker youtubeAdBlocker) {
+                                                            YoutubeAdBlocker youtubeAdBlocker,
+                                                            SuccessfulSSLDetector successfulSSLDetector) {
         return Arrays.asList(
+                successfulSSLDetector,
                 sessionProcessor,
                 ignoreEBlockerProcessor,
                 pageContextProcessor,

--- a/eblocker-icapserver/src/main/java/org/eblocker/server/icap/transaction/processor/SuccessfulSSLDetector.java
+++ b/eblocker-icapserver/src/main/java/org/eblocker/server/icap/transaction/processor/SuccessfulSSLDetector.java
@@ -1,0 +1,32 @@
+package org.eblocker.server.icap.transaction.processor;
+
+import com.google.inject.Inject;
+import com.google.inject.Singleton;
+import org.eblocker.server.common.util.UrlUtils;
+import org.eblocker.server.http.service.AutoTrustAppService;
+import org.eblocker.server.icap.transaction.Transaction;
+import org.eblocker.server.icap.transaction.TransactionProcessor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+@Singleton
+public class SuccessfulSSLDetector implements TransactionProcessor {
+
+    private final AutoTrustAppService autoTrustAppService;
+    private static final Logger log = LoggerFactory.getLogger(SuccessfulSSLDetector.class);
+
+    @Inject
+    public SuccessfulSSLDetector(AutoTrustAppService autoTrustAppService) {
+        this.autoTrustAppService = autoTrustAppService;
+    }
+
+    @Override
+    public boolean process(Transaction transaction) {
+        String url = transaction.getUrl();
+        if (url != null && url.startsWith("https")) {
+            log.debug("Processing HTTPS URL " + url);
+            autoTrustAppService.recordSuccessfulSSL(UrlUtils.getHostname(url));
+        }
+        return true;
+    }
+}

--- a/eblocker-icapserver/src/test/java/org/eblocker/server/http/service/SuccessfulSSLDomainsTest.java
+++ b/eblocker-icapserver/src/test/java/org/eblocker/server/http/service/SuccessfulSSLDomainsTest.java
@@ -1,0 +1,27 @@
+package org.eblocker.server.http.service;
+
+import org.junit.Test;
+
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class SuccessfulSSLDomainsTest {
+
+    @Test
+    public void testAddingRandomStrings() {
+        SuccessfulSSLDomains testee = new SuccessfulSSLDomains(1000, 100, 0.001);
+
+        List<String> domains = IntStream.range(1, 4000)
+                .mapToObj(i -> Integer.toString(i).repeat(i) + "foo.com")
+                .collect(Collectors.toList());
+
+        domains.forEach(testee::recordDomain);
+
+        assertTrue(testee.isDomainAlreadySucessful(domains.get(domains.size() - 10))); // some recently added domain
+        assertFalse(testee.isDomainAlreadySucessful(domains.get(0)));
+    }
+}


### PR DESCRIPTION
- record already successful SSL domains and never whitelist them
- Whitelist on certain certificate-related errors right away
- Ignore errors on non-SSL-enabled devices