### PR TITLE
Add transaction processor to remove common tracking parameters from URL query strings

### DIFF
--- a/eblocker-icapserver/src/main/java/org/eblocker/server/icap/transaction/TransactionProcessorsModule.java
+++ b/eblocker-icapserver/src/main/java/org/eblocker/server/icap/transaction/TransactionProcessorsModule.java
@@ -40,6 +40,7 @@ import org.eblocker.server.icap.transaction.processor.PageContextProcessor;
 import org.eblocker.server.icap.transaction.processor.PatternFilterStatisticsProcessor;
 import org.eblocker.server.icap.transaction.processor.RedirectFromSetupPageProcessor;
 import org.eblocker.server.icap.transaction.processor.ReferrerRemoveProcessor;
+import org.eblocker.server.icap.transaction.processor.RemoveTrackingParametersProcessor;
 import org.eblocker.server.icap.transaction.processor.ResponseShortCutProcessor;
 import org.eblocker.server.icap.transaction.processor.SessionProcessor;
 import org.eblocker.server.icap.transaction.processor.SetBaseUrlProcessor;
@@ -74,6 +75,7 @@ public class TransactionProcessorsModule extends AbstractModule {
                                                            PatternFilterStatisticsProcessor patternFilterStatisticsProcessor,
                                                            RedirectFromSetupPageProcessor redirectToInternalWebsiteProcessor,
                                                            ReferrerRemoveProcessor referrerRemoveProcessor,
+                                                           RemoveTrackingParametersProcessor removeTrackingParametersProcessor,
                                                            SessionProcessor sessionProcessor,
                                                            SetBaseUrlProcessor setBaseUrlProcessor,
                                                            SetDntHeaderProcessor setDntHeaderProcessor,
@@ -98,6 +100,7 @@ public class TransactionProcessorsModule extends AbstractModule {
                 adBlockerProcessor,
                 trackingBlockerProcessor,
                 referrerRemoveProcessor,
+                removeTrackingParametersProcessor,
                 setDntHeaderProcessor,
                 finalizeProcessor
         );

--- a/eblocker-icapserver/src/main/java/org/eblocker/server/icap/transaction/processor/RemoveTrackingParametersProcessor.java
+++ b/eblocker-icapserver/src/main/java/org/eblocker/server/icap/transaction/processor/RemoveTrackingParametersProcessor.java
@@ -1,0 +1,63 @@
+package org.eblocker.server.icap.transaction.processor;
+
+import com.google.inject.Singleton;
+import io.netty.handler.codec.http.FullHttpRequest;
+import org.eblocker.server.icap.transaction.Transaction;
+import org.eblocker.server.icap.transaction.TransactionProcessor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.List;
+
+@Singleton
+public class RemoveTrackingParametersProcessor implements TransactionProcessor {
+
+    private static final Logger log = LoggerFactory.getLogger(RemoveTrackingParametersProcessor.class);
+
+    private static final List<String> TRACKING_PARAMS = List.of("gclid", "msclkid", "fbclid", "utm_campaign", "utm_term", "utm_medium", "utm_source", "utm_content", "fb_action_ids", "fb_action_types", "fb_source", "fb_ref", "ga_source", "ga_medium",
+            "ga_term",
+            "ga_content", "ga_campaign", "ga_place", "action_object_map", "action_type_map", "action_ref_map", "gs_l", "mkt_tok", "hmb_campaign", "hmb_source", "hmb_medium", "aff", "KNC", "oq", "prmd");
+
+    @Override
+    public boolean process(Transaction transaction) {
+        if (transaction.isResponse()) {//just for requests, because they contain the http header
+            return true;
+        }
+        FullHttpRequest request = transaction.getRequest();
+
+        String requestUri = request.uri();
+        try {
+            URL url = new URL(requestUri);
+            String query = url.getQuery();
+
+            if (query != null) {
+                String[] params = query.split("&");
+                List<String> filteredParams = new ArrayList<>(params.length);
+                boolean removed = false;
+                for (String param : params) {
+                    if (TRACKING_PARAMS.contains(param.split("=")[0])) {
+                        removed = true;
+                    } else {
+                        filteredParams.add(param);
+                    }
+                }
+                if (removed) {
+                    String newQuery = String.join("&", filteredParams);
+                    String newUrl = url.getProtocol() + "://" +
+                            url.getAuthority() +
+                            url.getPath() +
+                            (newQuery.isBlank() ? "" : "?" + newQuery) +
+                            (url.getRef() == null ? "" : "#" + url.getRef());
+                    request.setUri(newUrl);
+                    // TODO: do we need to notify the transaction that the Uri changed?
+                    log.warn("Removed tracking parameter from >>" + requestUri + "<< to >>" + newUrl + "<<");
+                }
+            }
+        } catch (Exception e) {
+            log.error("Cannot parse " + requestUri, e);
+        }
+        return true;
+    }
+}

--- a/eblocker-icapserver/src/main/java/org/eblocker/server/icap/transaction/processor/RemoveTrackingParametersProcessor.java
+++ b/eblocker-icapserver/src/main/java/org/eblocker/server/icap/transaction/processor/RemoveTrackingParametersProcessor.java
@@ -10,13 +10,14 @@ import org.slf4j.LoggerFactory;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Set;
 
 @Singleton
 public class RemoveTrackingParametersProcessor implements TransactionProcessor {
 
     private static final Logger log = LoggerFactory.getLogger(RemoveTrackingParametersProcessor.class);
 
-    private static final List<String> TRACKING_PARAMS = List.of("gclid", "msclkid", "fbclid", "utm_campaign", "utm_term", "utm_medium", "utm_source", "utm_content", "fb_action_ids", "fb_action_types", "fb_source", "fb_ref", "ga_source", "ga_medium",
+    private static final Set<String> TRACKING_PARAMS = Set.of("gclid", "msclkid", "fbclid", "utm_campaign", "utm_term", "utm_medium", "utm_source", "utm_content", "fb_action_ids", "fb_action_types", "fb_source", "fb_ref", "ga_source", "ga_medium",
             "ga_term",
             "ga_content", "ga_campaign", "ga_place", "action_object_map", "action_type_map", "action_ref_map", "gs_l", "mkt_tok", "hmb_campaign", "hmb_source", "hmb_medium", "aff", "KNC", "oq", "prmd");
 
@@ -51,7 +52,7 @@ public class RemoveTrackingParametersProcessor implements TransactionProcessor {
                             (newQuery.isBlank() ? "" : "?" + newQuery) +
                             (url.getRef() == null ? "" : "#" + url.getRef());
                     request.setUri(newUrl);
-                    // TODO: do we need to notify the transaction that the Uri changed?
+                    transaction.setHeadersChanged(true);
                     log.warn("Removed tracking parameter from >>" + requestUri + "<< to >>" + newUrl + "<<");
                 }
             }

--- a/eblocker-icapserver/src/test/java/org/eblocker/server/icap/transaction/processor/RemoveTrackingParametersProcessorTest.java
+++ b/eblocker-icapserver/src/test/java/org/eblocker/server/icap/transaction/processor/RemoveTrackingParametersProcessorTest.java
@@ -1,0 +1,92 @@
+package org.eblocker.server.icap.transaction.processor;
+
+import io.netty.handler.codec.http.DefaultFullHttpRequest;
+import io.netty.handler.codec.http.FullHttpRequest;
+import io.netty.handler.codec.http.HttpMethod;
+import io.netty.handler.codec.http.HttpVersion;
+import org.eblocker.server.icap.transaction.Transaction;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import static org.junit.Assert.assertEquals;
+
+public class RemoveTrackingParametersProcessorTest {
+
+    private RemoveTrackingParametersProcessor testee;
+    private Transaction transaction;
+
+    @Before
+    public void setup() {
+        testee = new RemoveTrackingParametersProcessor();
+        transaction = Mockito.mock(Transaction.class);
+    }
+
+    @Test
+    public void process_removes_tracking_params() {
+
+        FullHttpRequest request = makeRequest("https://foo.com/?gclid=ItrackU&x=y&ga_term=trackingTerm");
+        Mockito.when(transaction.getRequest()).thenReturn(request);
+        testee.process(transaction);
+
+        assertEquals("https://foo.com/?x=y", request.uri());
+    }
+
+    private DefaultFullHttpRequest makeRequest(String uri) {
+        return new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, uri);
+    }
+
+    @Test
+    public void process_removes_query_for_single_tracking_param() {
+        FullHttpRequest request = makeRequest("https://foo.com/?gclid=ItrackU");
+        Mockito.when(transaction.getRequest()).thenReturn(request);
+        testee.process(transaction);
+
+        assertEquals("https://foo.com/", request.uri());
+    }
+
+    @Test
+    public void process_preserves_escapes() {
+        FullHttpRequest request = makeRequest("https://foo.com/path%20%C3%BC?gclid=ItrackU&a%20=b%21&x=y");
+        Mockito.when(transaction.getRequest()).thenReturn(request);
+        testee.process(transaction);
+
+        assertEquals("https://foo.com/path%20%C3%BC?a%20=b%21&x=y", request.uri());
+    }
+
+    @Test
+    public void process_preserves_fragment() {
+        FullHttpRequest request = makeRequest("https://foo.com/path?gclid=ItrackU&a=b#ABC");
+        Mockito.when(transaction.getRequest()).thenReturn(request);
+        testee.process(transaction);
+
+        assertEquals("https://foo.com/path?a=b#ABC", request.uri());
+    }
+
+    @Test
+    public void process_preserves_port() {
+        FullHttpRequest request = makeRequest("https://foo.com:8443/path?gclid=ItrackU&a=b");
+        Mockito.when(transaction.getRequest()).thenReturn(request);
+        testee.process(transaction);
+
+        assertEquals("https://foo.com:8443/path?a=b", request.uri());
+    }
+
+    @Test
+    public void process_preserves_userinfo() {
+        FullHttpRequest request = makeRequest("https://user:password@foo.com/path?gclid=ItrackU&a=b");
+        Mockito.when(transaction.getRequest()).thenReturn(request);
+        testee.process(transaction);
+
+        assertEquals("https://user:password@foo.com/path?a=b", request.uri());
+    }
+
+    @Test
+    public void process_untouched() {
+        FullHttpRequest request = makeRequest("https://foo.com/?a=b&c=d");
+        Mockito.when(transaction.getRequest()).thenReturn(request);
+        testee.process(transaction);
+
+        assertEquals("https://foo.com/?a=b&c=d", request.uri());
+    }
+}


### PR DESCRIPTION
As discussed, this is just an initial version to test the feature on the dev stage:
- Parameters are hard-coded
- Currently no way to turn it off
- Logs on level WARN if parameters are removed