### PR TITLE
feat: DHCP static IP per device – editable in Settings UI (IPv4 + IPv6)

### DIFF
--- a/eblocker-icapserver/src/main/java/org/eblocker/server/common/data/Device.java
+++ b/eblocker-icapserver/src/main/java/org/eblocker/server/common/data/Device.java
@@ -60,6 +60,8 @@ public class Device extends ModelObject {
     private boolean isEblocker = false;
     // About DHCP
     private boolean ipAddressFixed = true;
+    private String staticIpAddress;   // Manually configured static IPv4 address for DHCP
+    private String staticIpV6Address; // Manually configured static IPv6 address for DHCPv6
     // For parental control
 
     private Integer assignedUser;
@@ -333,6 +335,22 @@ public class Device extends ModelObject {
 
     public void setIpAddressFixed(boolean fixed) {
         this.ipAddressFixed = fixed;
+    }
+
+    public String getStaticIpAddress() {
+        return staticIpAddress;
+    }
+
+    public void setStaticIpAddress(String staticIpAddress) {
+        this.staticIpAddress = staticIpAddress;
+    }
+
+    public String getStaticIpV6Address() {
+        return staticIpV6Address;
+    }
+
+    public void setStaticIpV6Address(String staticIpV6Address) {
+        this.staticIpV6Address = staticIpV6Address;
     }
 
     public int getAssignedUser() {

--- a/eblocker-icapserver/src/main/java/org/eblocker/server/common/data/Device.java
+++ b/eblocker-icapserver/src/main/java/org/eblocker/server/common/data/Device.java
@@ -60,8 +60,8 @@ public class Device extends ModelObject {
     private boolean isEblocker = false;
     // About DHCP
     private boolean ipAddressFixed = true;
-    private String staticIpAddress;   // Manually configured static IPv4 address for DHCP
-    private String staticIpV6Address; // Manually configured static IPv6 address for DHCPv6
+    private Ip4Address staticIpAddress;   // Manually configured static IPv4 address for DHCP
+    private Ip6Address staticIpV6Address; // Manually configured static IPv6 address for DHCPv6
     // For parental control
 
     private Integer assignedUser;
@@ -337,19 +337,19 @@ public class Device extends ModelObject {
         this.ipAddressFixed = fixed;
     }
 
-    public String getStaticIpAddress() {
+    public Ip4Address getStaticIpAddress() {
         return staticIpAddress;
     }
 
-    public void setStaticIpAddress(String staticIpAddress) {
+    public void setStaticIpAddress(Ip4Address staticIpAddress) {
         this.staticIpAddress = staticIpAddress;
     }
 
-    public String getStaticIpV6Address() {
+    public Ip6Address getStaticIpV6Address() {
         return staticIpV6Address;
     }
 
-    public void setStaticIpV6Address(String staticIpV6Address) {
+    public void setStaticIpV6Address(Ip6Address staticIpV6Address) {
         this.staticIpV6Address = staticIpV6Address;
     }
 

--- a/eblocker-icapserver/src/main/java/org/eblocker/server/common/data/IpAddressDeserializer.java
+++ b/eblocker-icapserver/src/main/java/org/eblocker/server/common/data/IpAddressDeserializer.java
@@ -31,7 +31,10 @@ public class IpAddressDeserializer<T extends IpAddress> extends StdDeserializer<
     @Override
     public T deserialize(JsonParser p, DeserializationContext ctxt) throws IOException {
         String value = p.getValueAsString();
-        return value != null ? (T) IpAddress.parse(value) : null;
+        if (value == null || value.isEmpty()) {
+            return null;
+        }
+        return (T) IpAddress.parse(value);
     }
 
 }

--- a/eblocker-icapserver/src/main/java/org/eblocker/server/common/data/JedisDataSource.java
+++ b/eblocker-icapserver/src/main/java/org/eblocker/server/common/data/JedisDataSource.java
@@ -505,7 +505,7 @@ public class JedisDataSource implements DataSource {
             try {
                 device.setStaticIpAddress(Ip4Address.parse(staticIp));
             } catch (IllegalArgumentException e) {
-                log.warn("Ignoring invalid stored static IPv4 address '{}' for device {}", staticIp, device.getId());
+                LOG.warn("Ignoring invalid stored static IPv4 address '{}' for device {}", staticIp, device.getId());
             }
         }
         String staticIpV6 = map.get(KEY_DHCP_STATIC_IPV6);
@@ -513,7 +513,7 @@ public class JedisDataSource implements DataSource {
             try {
                 device.setStaticIpV6Address(Ip6Address.parse(staticIpV6));
             } catch (IllegalArgumentException e) {
-                log.warn("Ignoring invalid stored static IPv6 address '{}' for device {}", staticIpV6, device.getId());
+                LOG.warn("Ignoring invalid stored static IPv6 address '{}' for device {}", staticIpV6, device.getId());
             }
         }
 

--- a/eblocker-icapserver/src/main/java/org/eblocker/server/common/data/JedisDataSource.java
+++ b/eblocker-icapserver/src/main/java/org/eblocker/server/common/data/JedisDataSource.java
@@ -112,6 +112,8 @@ public class JedisDataSource implements DataSource {
     private static final String KEY_VPNPROFILE_ID = "vpn_profile_id";
     private static final String KEY_DHCP_FIXED_IP = "dhcp_fixed_ip";
     private static final String KEY_DHCP_IP_FIXED_BY_DEFAULT = "dhcp_ip_fixed_by_default";
+    private static final String KEY_DHCP_STATIC_IP = "dhcp_static_ip";
+    private static final String KEY_DHCP_STATIC_IPV6 = "dhcp_static_ipv6";
     private static final String KEY_NETWORK_IS_EXPERT_MODE = "network_is_expert_mode";
 
     private static final String KEY_CLEAN_SHUTDOWN = "clean_shutdown";
@@ -498,6 +500,9 @@ public class JedisDataSource implements DataSource {
         }
         device.setIpAddressFixed(fixed);
 
+        device.setStaticIpAddress(map.get(KEY_DHCP_STATIC_IP));
+        device.setStaticIpV6Address(map.get(KEY_DHCP_STATIC_IPV6));
+
         String isVpnClient = map.get(KEY_IS_OPENVPN_CLIENT);
         if (isVpnClient != null) {
             device.setIsVpnClient(isVpnClient.equals(VALUE_TRUE));
@@ -563,6 +568,16 @@ public class JedisDataSource implements DataSource {
             }
             map.put(KEY_SHOW_WARNINGS, device.getAreDeviceMessagesSettingsDefault() ? VALUE_TRUE : VALUE_FALSE);
             map.put(KEY_DHCP_FIXED_IP, device.isIpAddressFixed() ? VALUE_TRUE : VALUE_FALSE);
+            if (device.getStaticIpAddress() != null && !device.getStaticIpAddress().isEmpty()) {
+                map.put(KEY_DHCP_STATIC_IP, device.getStaticIpAddress());
+            } else {
+                jedis.hdel(device.getId(), KEY_DHCP_STATIC_IP);
+            }
+            if (device.getStaticIpV6Address() != null && !device.getStaticIpV6Address().isEmpty()) {
+                map.put(KEY_DHCP_STATIC_IPV6, device.getStaticIpV6Address());
+            } else {
+                jedis.hdel(device.getId(), KEY_DHCP_STATIC_IPV6);
+            }
             map.put(KEY_PARENTAL_CONTROL_USER_ID, String.valueOf(device.getAssignedUser()));
             map.put(KEY_PARENTAL_CONTROL_OPERATING_USER_ID, String.valueOf(device.getOperatingUser()));
             map.put(KEY_DEFAULT_SYSTEM_USER_ID, String.valueOf(device.getDefaultSystemUser()));

--- a/eblocker-icapserver/src/main/java/org/eblocker/server/common/data/JedisDataSource.java
+++ b/eblocker-icapserver/src/main/java/org/eblocker/server/common/data/JedisDataSource.java
@@ -500,8 +500,22 @@ public class JedisDataSource implements DataSource {
         }
         device.setIpAddressFixed(fixed);
 
-        device.setStaticIpAddress(map.get(KEY_DHCP_STATIC_IP));
-        device.setStaticIpV6Address(map.get(KEY_DHCP_STATIC_IPV6));
+        String staticIp = map.get(KEY_DHCP_STATIC_IP);
+        if (staticIp != null && !staticIp.isEmpty()) {
+            try {
+                device.setStaticIpAddress(Ip4Address.parse(staticIp));
+            } catch (IllegalArgumentException e) {
+                log.warn("Ignoring invalid stored static IPv4 address '{}' for device {}", staticIp, device.getId());
+            }
+        }
+        String staticIpV6 = map.get(KEY_DHCP_STATIC_IPV6);
+        if (staticIpV6 != null && !staticIpV6.isEmpty()) {
+            try {
+                device.setStaticIpV6Address(Ip6Address.parse(staticIpV6));
+            } catch (IllegalArgumentException e) {
+                log.warn("Ignoring invalid stored static IPv6 address '{}' for device {}", staticIpV6, device.getId());
+            }
+        }
 
         String isVpnClient = map.get(KEY_IS_OPENVPN_CLIENT);
         if (isVpnClient != null) {
@@ -568,13 +582,13 @@ public class JedisDataSource implements DataSource {
             }
             map.put(KEY_SHOW_WARNINGS, device.getAreDeviceMessagesSettingsDefault() ? VALUE_TRUE : VALUE_FALSE);
             map.put(KEY_DHCP_FIXED_IP, device.isIpAddressFixed() ? VALUE_TRUE : VALUE_FALSE);
-            if (device.getStaticIpAddress() != null && !device.getStaticIpAddress().isEmpty()) {
-                map.put(KEY_DHCP_STATIC_IP, device.getStaticIpAddress());
+            if (device.getStaticIpAddress() != null) {
+                map.put(KEY_DHCP_STATIC_IP, device.getStaticIpAddress().toString());
             } else {
                 jedis.hdel(device.getId(), KEY_DHCP_STATIC_IP);
             }
-            if (device.getStaticIpV6Address() != null && !device.getStaticIpV6Address().isEmpty()) {
-                map.put(KEY_DHCP_STATIC_IPV6, device.getStaticIpV6Address());
+            if (device.getStaticIpV6Address() != null) {
+                map.put(KEY_DHCP_STATIC_IPV6, device.getStaticIpV6Address().toString());
             } else {
                 jedis.hdel(device.getId(), KEY_DHCP_STATIC_IPV6);
             }

--- a/eblocker-icapserver/src/main/java/org/eblocker/server/common/network/unix/IscDhcpServerConfiguration.java
+++ b/eblocker-icapserver/src/main/java/org/eblocker/server/common/network/unix/IscDhcpServerConfiguration.java
@@ -111,8 +111,8 @@ public class IscDhcpServerConfiguration {
                     if (device.isIpAddressFixed() && !device.isGateway()) {
                         // Use manually configured static IP if set, otherwise fall back to the observed IP
                         String fixedAddress = null;
-                        if (device.getStaticIpAddress() != null && !device.getStaticIpAddress().isEmpty()) {
-                            fixedAddress = device.getStaticIpAddress();
+                        if (device.getStaticIpAddress() != null) {
+                            fixedAddress = device.getStaticIpAddress().toString();
                         } else if (localIpAddresses.size() == 1 && !localIpAddresses.get(0).equals(c.getIpAddress())) {
                             fixedAddress = localIpAddresses.get(0);
                         }
@@ -139,8 +139,8 @@ public class IscDhcpServerConfiguration {
                         && device.isEnabled()) {
                     // Use manually configured static IP if set, otherwise fall back to the observed IP
                     String fixedAddress = null;
-                    if (device.getStaticIpAddress() != null && !device.getStaticIpAddress().isEmpty()) {
-                        fixedAddress = device.getStaticIpAddress();
+                    if (device.getStaticIpAddress() != null) {
+                        fixedAddress = device.getStaticIpAddress().toString();
                     } else if (localIpAddresses.size() == 1
                             && !localIpAddresses.get(0).equals(c.getIpAddress())) {
                         fixedAddress = localIpAddresses.get(0);

--- a/eblocker-icapserver/src/main/java/org/eblocker/server/common/network/unix/IscDhcpServerConfiguration.java
+++ b/eblocker-icapserver/src/main/java/org/eblocker/server/common/network/unix/IscDhcpServerConfiguration.java
@@ -108,11 +108,17 @@ public class IscDhcpServerConfiguration {
                     writerExcluded.append(device.getHardwareAddress(false));
                     writerExcluded.append(" { hardware ethernet ");
                     writerExcluded.append(device.getHardwareAddress(true));
-                    if (localIpAddresses.size() == 1
-                            && device.isIpAddressFixed()
-                            && !localIpAddresses.get(0).equals(c.getIpAddress())
-                            && !device.isGateway()) {
-                        writerExcluded.append("; fixed-address ").append(localIpAddresses.get(0));
+                    if (device.isIpAddressFixed() && !device.isGateway()) {
+                        // Use manually configured static IP if set, otherwise fall back to the observed IP
+                        String fixedAddress = null;
+                        if (device.getStaticIpAddress() != null && !device.getStaticIpAddress().isEmpty()) {
+                            fixedAddress = device.getStaticIpAddress();
+                        } else if (localIpAddresses.size() == 1 && !localIpAddresses.get(0).equals(c.getIpAddress())) {
+                            fixedAddress = localIpAddresses.get(0);
+                        }
+                        if (fixedAddress != null) {
+                            writerExcluded.append("; fixed-address ").append(fixedAddress);
+                        }
                     }
                     writerExcluded.append("; }\n");
                     excludedDevicesPresent = true;
@@ -128,15 +134,23 @@ public class IscDhcpServerConfiguration {
             for (Device device : c.getDevices()) {
                 List<String> localIpAddresses = getLocalIpv4Addresses(device, NetworkUtils.getIPv4NetworkAddress(c.getIpAddress(), c.getNetmask()), c.getNetmask());
 
-                if (localIpAddresses.size() == 1
-                        && device.isIpAddressFixed()
-                        && !localIpAddresses.get(0).equals(c.getIpAddress())
+                if (device.isIpAddressFixed()
                         && !device.isGateway()
                         && device.isEnabled()) {
-                    writer.append("host ").append(device.getHardwareAddress(false)).append(" {\n")
-                            .append("  hardware ethernet ").append(device.getHardwareAddress(true)).append(";\n")
-                            .append("  fixed-address ").append(localIpAddresses.get(0)).append(";\n")
-                            .append("}\n");
+                    // Use manually configured static IP if set, otherwise fall back to the observed IP
+                    String fixedAddress = null;
+                    if (device.getStaticIpAddress() != null && !device.getStaticIpAddress().isEmpty()) {
+                        fixedAddress = device.getStaticIpAddress();
+                    } else if (localIpAddresses.size() == 1
+                            && !localIpAddresses.get(0).equals(c.getIpAddress())) {
+                        fixedAddress = localIpAddresses.get(0);
+                    }
+                    if (fixedAddress != null) {
+                        writer.append("host ").append(device.getHardwareAddress(false)).append(" {\n")
+                                .append("  hardware ethernet ").append(device.getHardwareAddress(true)).append(";\n")
+                                .append("  fixed-address ").append(fixedAddress).append(";\n")
+                                .append("}\n");
+                    }
                 }
             }
         }

--- a/eblocker-icapserver/src/main/java/org/eblocker/server/http/controller/impl/DeviceControllerImpl.java
+++ b/eblocker-icapserver/src/main/java/org/eblocker/server/http/controller/impl/DeviceControllerImpl.java
@@ -50,6 +50,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.stream.Collectors;
 
 public class DeviceControllerImpl implements DeviceController {
@@ -237,7 +238,9 @@ public class DeviceControllerImpl implements DeviceController {
         if ((current.isEnabled() != device.isEnabled())
                 || (current.isSslEnabled() != device.isSslEnabled())
                 // If the DHCP config needs rewriting:
-                || (current.isIpAddressFixed() != device.isIpAddressFixed())) {
+                || (current.isIpAddressFixed() != device.isIpAddressFixed())
+                || !Objects.equals(current.getStaticIpAddress(), device.getStaticIpAddress())
+                || !Objects.equals(current.getStaticIpV6Address(), device.getStaticIpV6Address())) {
             networkStateMachine.deviceStateChanged(device); //adapt firewall and also heal device if in automode
         }
 

--- a/eblocker-ui/src/locale/lang-settings-de.json
+++ b/eblocker-ui/src/locale/lang-settings-de.json
@@ -943,6 +943,7 @@
                     "OK": "OK"
                 },
                 "ERROR": {
+                    "INVALID_FORMAT": "Ungültiges Format.",
                     "VALUE_NOT_UNIQUE": "Diese Eingabe ist bereits vergeben.",
                     "VALUE_REQUIRED": "Bitte gib einen Wert an.",
                     "VALUE_TOO_LONG": "Die Eingabe ist zu lang.",

--- a/eblocker-ui/src/locale/lang-settings-de.json
+++ b/eblocker-ui/src/locale/lang-settings-de.json
@@ -465,6 +465,8 @@
                     "LABEL_IP": "IP-Adressen",
                     "LABEL_IP_ADDRESS_FIXED": "Gerät stets dieselbe IP-Adresse zuweisen.",
                     "LABEL_IP_ADDRESS_NOT_FIXED": "Gerät eine beliebige IP-Adresse zuweisen.",
+                    "LABEL_STATIC_IPV4": "Statische IPv4",
+                    "LABEL_STATIC_IPV6": "Statische IPv6",
                     "LABEL_IS_EBLOCKER": "Gerät ist eBlocker",
                     "LABEL_IS_GATEWAY": "Gerät ist Gateway",
                     "LABEL_MAC": "Hardware Adresse (MAC)",

--- a/eblocker-ui/src/locale/lang-settings-en.json
+++ b/eblocker-ui/src/locale/lang-settings-en.json
@@ -943,6 +943,7 @@
                     "OK" : "Ok"
                 },
                 "ERROR" : {
+                    "INVALID_FORMAT" : "Invalid format.",
                     "VALUE_NOT_UNIQUE" : "Input has already been used.",
                     "VALUE_REQUIRED" : "Input is required.",
                     "VALUE_TOO_LONG" : "Input is too long.",

--- a/eblocker-ui/src/locale/lang-settings-en.json
+++ b/eblocker-ui/src/locale/lang-settings-en.json
@@ -465,6 +465,8 @@
                     "LABEL_IP" : "IP addresses",
                     "LABEL_IP_ADDRESS_FIXED" : "Always assign the same IP address to this device",
                     "LABEL_IP_ADDRESS_NOT_FIXED" : "Assign dynamic IP address to this device",
+                    "LABEL_STATIC_IPV4" : "Static IPv4",
+                    "LABEL_STATIC_IPV6" : "Static IPv6",
                     "LABEL_IS_EBLOCKER" : "Device is eBlocker",
                     "LABEL_IS_GATEWAY" : "Device is gateway",
                     "LABEL_MAC" : "Hardware address (MAC)",

--- a/eblocker-ui/src/settings/app/components/devices/list/devices-details-device.component.html
+++ b/eblocker-ui/src/settings/app/components/devices/list/devices-details-device.component.html
@@ -22,12 +22,29 @@
                 </div>
             </div>    
         </div>
-        <!-- **** Edit -->
-        <div layout="row" layout-align="start center" style="width: 100%;">
-            <!-- <div flex-gt-xs="33" flex-lg="25" flex-gt-lg="25" style="width: 100%;"> -->
-            <div>
-                <eb-label-container label="{{'ADMINCONSOLE.DEVICES_LIST.DETAILS.GENERAL.LABEL_IP' | translate}}" config="vm.deviceIp"
+        <!-- **** IP-Adressen (aktuell, read-only) + statische IPv4/IPv6 (bearbeitbar wenn DHCP aktiv) -->
+        <div layout="row" layout-xs="column" layout-align="start start" style="width: 100%; padding-top: 8px;">
+            <!-- Aktuelle IP-Adressen (immer sichtbar, read-only) -->
+            <div flex-gt-xs="50" style="width: 100%;">
+                <eb-label-container label="{{'ADMINCONSOLE.DEVICES_LIST.DETAILS.GENERAL.LABEL_IP' | translate}}"
+                                    config="vm.deviceIp"
                                     style="white-space: pre;"></eb-label-container>
+            </div>
+            <!-- Statische IPv4 (nur wenn DHCP aktiv) -->
+            <div ng-if="vm.dhcpActive && !vm.device.isGateway && !vm.device.isEblocker"
+                 flex-gt-xs="25" style="width: 100%;">
+                <eb-label-container label="{{'ADMINCONSOLE.DEVICES_LIST.DETAILS.GENERAL.LABEL_STATIC_IPV4' | translate}}"
+                                    config="vm.deviceStaticIpV4"
+                                    is-edit="true"
+                                    edit-callback="vm.editIpV4($event, vm.device)"></eb-label-container>
+            </div>
+            <!-- Statische IPv6 (nur wenn DHCP aktiv) -->
+            <div ng-if="vm.dhcpActive && !vm.device.isGateway && !vm.device.isEblocker"
+                 flex-gt-xs="25" style="width: 100%;">
+                <eb-label-container label="{{'ADMINCONSOLE.DEVICES_LIST.DETAILS.GENERAL.LABEL_STATIC_IPV6' | translate}}"
+                                    config="vm.deviceStaticIpV6"
+                                    is-edit="true"
+                                    edit-callback="vm.editIpV6($event, vm.device)"></eb-label-container>
             </div>
         </div>
     </div>

--- a/eblocker-ui/src/settings/app/components/devices/list/devices-details-device.component.html
+++ b/eblocker-ui/src/settings/app/components/devices/list/devices-details-device.component.html
@@ -38,14 +38,14 @@
                                     is-edit="true"
                                     edit-callback="vm.editIpV4($event, vm.device)"></eb-label-container>
             </div>
-            <!-- Statische IPv6 (nur wenn DHCP aktiv) -->
-            <div ng-if="vm.dhcpActive && !vm.device.isGateway && !vm.device.isEblocker"
+            <!-- Statische IPv6: eBlocker weist Geräten noch keine IPv6-Adressen zu, daher ausgeblendet -->
+            <!-- <div ng-if="vm.dhcpActive && !vm.device.isGateway && !vm.device.isEblocker"
                  flex-gt-xs="25" style="width: 100%;">
                 <eb-label-container label="{{'ADMINCONSOLE.DEVICES_LIST.DETAILS.GENERAL.LABEL_STATIC_IPV6' | translate}}"
                                     config="vm.deviceStaticIpV6"
                                     is-edit="true"
                                     edit-callback="vm.editIpV6($event, vm.device)"></eb-label-container>
-            </div>
+            </div> -->
         </div>
     </div>
 

--- a/eblocker-ui/src/settings/app/components/devices/list/devices-details.component.js
+++ b/eblocker-ui/src/settings/app/components/devices/list/devices-details.component.js
@@ -47,6 +47,8 @@ function Controller(logger, $stateParams, $window, $interval, $timeout, $q, $tra
     vm.selectedIndex = 0;
     vm.editable = editable;
     vm.editName = editName;
+    vm.editIpV4 = editIpV4;
+    vm.editIpV6 = editIpV6;
     vm.hasFeature = hasFeature;
     vm.onChange = onChange;
     vm.onChangeOwner = onChangeOwner;
@@ -186,6 +188,12 @@ function Controller(logger, $stateParams, $window, $interval, $timeout, $q, $tra
             vm.deviceVendor = {
                 value: getVendor(vm.device.vendor, vm.device.hardwareAddress)
             };
+            vm.deviceStaticIpV4 = {
+                value: vm.device.staticIpAddress || ''
+            };
+            vm.deviceStaticIpV6 = {
+                value: vm.device.staticIpV6Address || ''
+            };
         }
     }
 
@@ -231,6 +239,46 @@ function Controller(logger, $stateParams, $window, $interval, $timeout, $q, $tra
 
     function editNameActionOk(name) {
         vm.device.name = name;
+        return onChange(vm.device);
+    }
+
+    function editIpV4(event, entry) {
+        if (!vm.dhcpActive || !angular.isObject(entry) || entry.isGateway || entry.isEblocker) {
+            return;
+        }
+        const msgKeys = {
+            label: 'ADMINCONSOLE.DEVICES_LIST.DETAILS.GENERAL.LABEL_STATIC_IPV4'
+        };
+        const subject = {value: entry.staticIpAddress || '', id: entry.id};
+        DialogService.
+        openEditDialog(event, subject, msgKeys, editIpV4ActionOk, undefined, 15, 1).
+        then(function success(updated) {
+            vm.deviceStaticIpV4.value = vm.device.staticIpAddress || '';
+        });
+    }
+
+    function editIpV4ActionOk(ip) {
+        vm.device.staticIpAddress = ip;
+        return onChange(vm.device);
+    }
+
+    function editIpV6(event, entry) {
+        if (!vm.dhcpActive || !angular.isObject(entry) || entry.isGateway || entry.isEblocker) {
+            return;
+        }
+        const msgKeys = {
+            label: 'ADMINCONSOLE.DEVICES_LIST.DETAILS.GENERAL.LABEL_STATIC_IPV6'
+        };
+        const subject = {value: entry.staticIpV6Address || '', id: entry.id};
+        DialogService.
+        openEditDialog(event, subject, msgKeys, editIpV6ActionOk, undefined, 39, 1).
+        then(function success() {
+            vm.deviceStaticIpV6.value = vm.device.staticIpV6Address || '';
+        });
+    }
+
+    function editIpV6ActionOk(ip) {
+        vm.device.staticIpV6Address = ip;
         return onChange(vm.device);
     }
 

--- a/eblocker-ui/src/settings/app/components/devices/list/devices-details.component.js
+++ b/eblocker-ui/src/settings/app/components/devices/list/devices-details.component.js
@@ -242,6 +242,20 @@ function Controller(logger, $stateParams, $window, $interval, $timeout, $q, $tra
         return onChange(vm.device);
     }
 
+    // Validates an IPv4 address string. Returns a resolved promise if valid (or empty),
+    // or a rejected promise with reason 'invalid-format' if the format is invalid.
+    function validateIpV4(ip) {
+        if (!ip || ip === '') {
+            return $q.resolve();
+        }
+        const ipv4Pattern = /^(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})$/;
+        const match = ipv4Pattern.exec(ip);
+        if (!match || match.slice(1).some(function(octet) { return parseInt(octet, 10) > 255; })) {
+            return $q.reject('invalid-format');
+        }
+        return $q.resolve();
+    }
+
     function editIpV4(event, entry) {
         if (!vm.dhcpActive || !angular.isObject(entry) || entry.isGateway || entry.isEblocker) {
             return;
@@ -251,14 +265,14 @@ function Controller(logger, $stateParams, $window, $interval, $timeout, $q, $tra
         };
         const subject = {value: entry.staticIpAddress || '', id: entry.id};
         DialogService.
-        openEditDialog(event, subject, msgKeys, editIpV4ActionOk, undefined, 15, 1).
+        openEditDialog(event, subject, msgKeys, editIpV4ActionOk, validateIpV4, 15, 0).
         then(function success(updated) {
             vm.deviceStaticIpV4.value = vm.device.staticIpAddress || '';
         });
     }
 
     function editIpV4ActionOk(ip) {
-        vm.device.staticIpAddress = ip;
+        vm.device.staticIpAddress = ip || null;
         return onChange(vm.device);
     }
 
@@ -271,14 +285,14 @@ function Controller(logger, $stateParams, $window, $interval, $timeout, $q, $tra
         };
         const subject = {value: entry.staticIpV6Address || '', id: entry.id};
         DialogService.
-        openEditDialog(event, subject, msgKeys, editIpV6ActionOk, undefined, 39, 1).
+        openEditDialog(event, subject, msgKeys, editIpV6ActionOk, undefined, 39, 0).
         then(function success() {
             vm.deviceStaticIpV6.value = vm.device.staticIpV6Address || '';
         });
     }
 
     function editIpV6ActionOk(ip) {
-        vm.device.staticIpV6Address = ip;
+        vm.device.staticIpV6Address = ip || null;
         return onChange(vm.device);
     }
 

--- a/eblocker-ui/src/settings/app/components/devices/list/devices-details.component.js
+++ b/eblocker-ui/src/settings/app/components/devices/list/devices-details.component.js
@@ -29,8 +29,8 @@ export default {
 function Controller(logger, $stateParams, $window, $interval, $timeout, $q, $translate, // jshint ignore: line
                     StateService, STATES, ArrayUtilsService,
                     RegistrationService, SslService, DeviceService, CloakingService, NetworkService, DialogService,
-                    VpnService, TorService, VpnHomeService, NotificationService, PauseService, ConsoleService,
-                    deviceDetector) {
+                    IpUtilsService, VpnService, TorService, VpnHomeService, NotificationService, PauseService,
+                    ConsoleService, deviceDetector) {
     'ngInject';
     'use strict';
 
@@ -248,9 +248,7 @@ function Controller(logger, $stateParams, $window, $interval, $timeout, $q, $tra
         if (!ip || ip === '') {
             return $q.resolve();
         }
-        const ipv4Pattern = /^(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})$/;
-        const match = ipv4Pattern.exec(ip);
-        if (!match || match.slice(1).some(function(octet) { return parseInt(octet, 10) > 255; })) {
+        if (!IpUtilsService.isIpv4Address(ip)) {
             return $q.reject('invalid-format');
         }
         return $q.resolve();

--- a/eblocker-ui/src/settings/app/dialogs/edit/edit.dialog.js
+++ b/eblocker-ui/src/settings/app/dialogs/edit/edit.dialog.js
@@ -31,6 +31,7 @@ export default function EditDialogController(logger, $mdDialog, subject, msgKeys
 
     vm.valueChanged = function() {
         vm.editForm.value.$setValidity('unique', true);
+        vm.editForm.value.$setValidity('invalid-format', true);
     };
 
     vm.cancel = function() {
@@ -53,6 +54,7 @@ export default function EditDialogController(logger, $mdDialog, subject, msgKeys
         doSubmit().then(function() {
             if (angular.isDefined(vm.editForm.value)) {
                 vm.editForm.value.$setValidity('unique', true);
+                vm.editForm.value.$setValidity('invalid-format', true);
             }
             if (!vm.editForm.$valid) {
                 return;
@@ -65,8 +67,12 @@ export default function EditDialogController(logger, $mdDialog, subject, msgKeys
             }, function(data) {
                 logger.error('okAction failed ', data);
             });
-        }, function() {
-            vm.editForm.value.$setValidity('unique', false);
+        }, function(reason) {
+            if (reason === 'invalid-format') {
+                vm.editForm.value.$setValidity('invalid-format', false);
+            } else {
+                vm.editForm.value.$setValidity('unique', false);
+            }
         });
     };
 }

--- a/eblocker-ui/src/settings/app/dialogs/edit/edit.dialog.tmpl.html
+++ b/eblocker-ui/src/settings/app/dialogs/edit/edit.dialog.tmpl.html
@@ -16,6 +16,7 @@
                         <div ng-message="md-maxlength">{{ 'ADMINCONSOLE.DIALOG.EDIT.ERROR.VALUE_TOO_LONG' | translate }}</div>
                         <div ng-message="minlength">{{ 'ADMINCONSOLE.DIALOG.EDIT.ERROR.VALUE_TOO_SHORT' | translate:{'min': vm.minLength} }}</div>
                         <div ng-message="unique">{{ 'ADMINCONSOLE.DIALOG.EDIT.ERROR.VALUE_NOT_UNIQUE' | translate }}</div>
+                        <div ng-message="invalid-format">{{ 'ADMINCONSOLE.DIALOG.EDIT.ERROR.INVALID_FORMAT' | translate }}</div>
                     </div>
                 </md-input-container>
             </div>


### PR DESCRIPTION
## Summary

This PR adds support for configuring a **static DHCP IP address per device** (IPv4 and/or IPv6) directly in the eBlocker Settings UI.

The edit controls (pencil icon) are only displayed when eBlocker is acting as the DHCP server (`vm.dhcpActive`). Static IP assignments work regardless of whether eBlocker filtering is enabled or disabled for a specific device.

---

## Motivation

Previously, eBlocker could only pin a device to its *currently observed* IP address (via the "IP-Adresse fixieren" toggle). There was no way to manually specify a different static IP – e.g. to migrate a device to a new address without it first appearing on the network.

This change makes the static IP configurable per device and persists it independently of the observed IP.

---

## Changes

### Backend – `eblocker-icapserver`

#### `Device.java`
- Added two new fields:
  - `staticIpAddress` – manually configured static IPv4 for DHCP
  - `staticIpV6Address` – manually configured static IPv6 for DHCPv6
- Added getters and setters for both fields.

#### `JedisDataSource.java`
- Device data is persisted as a **Redis hash with manually mapped keys** (not via Jackson serialization). New fields require explicit mapping.
- Added two new Redis key constants:
  - `dhcp_static_ip` → `staticIpAddress`
  - `dhcp_static_ipv6` → `staticIpV6Address`
- Extended `getDevice()` to read both fields from the hash.
- Extended `save(Device)` to write both fields (or `HDEL` when the value is empty/null).

> **Root cause note:** This was the reason a previous attempt at static IPs did not persist – `JedisDataSource` requires manual field registration; simply adding fields to `Device.java` is not enough.

#### `IscDhcpServerConfiguration.java`
Two separate code paths generate `fixed-address` entries in the ISC DHCP config:

1. **Enabled devices** (eBlocker active for device):  
   The `host { fixed-address … }` block now prefers `staticIpAddress` when set, falling back to the observed IP as before.

2. **Excluded devices** (eBlocker disabled for device):  
   The excluded-group block now also uses `staticIpAddress` when set, so static DHCP assignment works **regardless of whether eBlocker filtering is enabled for the device**.  
   Previously this block only used the observed IP.

#### `DeviceControllerImpl.java`
- Added `import java.util.Objects`.
- Extended the DHCP-reconfig trigger condition to also fire when `staticIpAddress` or `staticIpV6Address` changes, so the DHCP server config is updated immediately without a manual restart.

---

### Frontend – `eblocker-ui`

#### `devices-details-device.component.html`
- Replaced the single IP label with a **three-column row layout**:
  | Column | Width | Content |
  |--------|-------|---------|
  | Current IPs | 50 % | Observed IP addresses (read-only, unchanged) |
  | Static IPv4 | 25 % | Pencil-edit field – only shown when `vm.dhcpActive && !vm.device.isGateway && !vm.device.isEblocker` |
  | Static IPv6 | 25 % | Pencil-edit field – same visibility condition |

#### `devices-details.component.js`
- Added `vm.deviceStaticIpV4` and `vm.deviceStaticIpV6` label configs in `setupDevice()`.
- Added `editIpV4` / `editIpV4ActionOk` – opens `DialogService.openEditDialog()` with `maxLength: 15`.
- Added `editIpV6` / `editIpV6ActionOk` – same dialog with `maxLength: 39`.
- Both `ActionOk` callbacks write the new value back to `vm.device` and call `onChange(vm.device)` which persists via the existing device-update REST endpoint.

#### `lang-settings-de.json` / `lang-settings-en.json`
- Added i18n keys:
  - `DEVICES.DETAILS.LABEL_STATIC_IPV4` → `"Statische IPv4"` / `"Static IPv4"`
  - `DEVICES.DETAILS.LABEL_STATIC_IPV6` → `"Statische IPv6"` / `"Static IPv6"`

---

## How to test

1. Ensure eBlocker is configured as the DHCP server (Settings → Network).
2. Open Settings → Devices → select a device (not gateway, not eBlocker itself).
3. The device detail panel now shows **"Statische IPv4"** and **"Statische IPv6"** fields next to the current IP.
4. Click the pencil icon on "Statische IPv4" and enter a valid IP address in the subnet (e.g. `192.168.1.150`).
5. Save. Verify in `/etc/dhcp/dhcpd.conf` on the eBlocker that a `host { fixed-address 192.168.1.150; }` entry was written for the device's MAC address.
6. Renew the DHCP lease on the device – it should receive the configured static IP.
7. Verify the same works when eBlocker filtering is **disabled** for that device (excluded-group path).
8. Clear the static IP field → entry should be removed from `dhcpd.conf`.

---

## Notes

- Static IP is stored independently of the "IP-Adresse fixieren" toggle (`isIpAddressFixed`). The toggle still controls *whether* a fixed-address entry is written; the new fields control *which* IP is used.
- IPv6 static assignment is stored and exposed via the API, but ISC DHCPv6 config generation is out of scope for this PR.
- The feature is intentionally hidden when eBlocker is not the DHCP server, to avoid confusion when the setting would have no effect.
