### PR TITLE
fix: persist learned pattern filter matches

### DIFF
--- a/eblocker-icapserver/src/main/java/org/eblocker/server/icap/filter/FilterManager.java
+++ b/eblocker-icapserver/src/main/java/org/eblocker/server/icap/filter/FilterManager.java
@@ -132,8 +132,6 @@ public class FilterManager {
     }
 
     public synchronized FilterStoreConfiguration addFilter(FilterStoreConfiguration configuration) {
-        FilterStore store = createFilterStore(configuration);
-
         int id = dataSource.nextId(FilterStoreConfiguration.class);
         FilterStoreConfiguration addedConfiguration = new FilterStoreConfiguration(id,
                 configuration.getName(),
@@ -146,6 +144,7 @@ public class FilterManager {
                 configuration.isLearnForAllDomains(),
                 configuration.getRuleFilters(),
                 configuration.isEnabled());
+        FilterStore store = createFilterStore(addedConfiguration);
 
         List<FilterStoreConfiguration> newConfigurations = new ArrayList<>(configurations);
         newConfigurations.add(addedConfiguration);
@@ -473,13 +472,20 @@ public class FilterManager {
 
     public Runnable getAsynchronousLearnersUpdater() {
         return () -> {
-            if (cache == null) {
-                return;
+            synchronized (FilterManager.this) {
+                if (cache == null) {
+                    return;
+                }
+                configurations.stream()
+                        .filter(configuration -> FilterLearningMode.ASYNCHRONOUS == configuration.getLearningMode())
+                        .forEach(configuration -> {
+                            FilterStore filterStore = cache.storeById.get(configuration.getId());
+                            AsynchronousLearningFilter filter = (AsynchronousLearningFilter) filterStore.getFilter();
+                            if (filter.processQueue()) {
+                                save(filterStore, configuration);
+                            }
+                        });
             }
-            configurations.stream()
-                    .filter(configuration -> FilterLearningMode.ASYNCHRONOUS == configuration.getLearningMode())
-                    .map(configuration -> ((Runnable) cache.storeById.get(configuration.getId()).getFilter()))
-                    .forEach(Runnable::run);
         };
     }
 

--- a/eblocker-icapserver/src/main/java/org/eblocker/server/icap/filter/learning/AsynchronousLearningFilter.java
+++ b/eblocker-icapserver/src/main/java/org/eblocker/server/icap/filter/learning/AsynchronousLearningFilter.java
@@ -55,14 +55,21 @@ public class AsynchronousLearningFilter extends LearningFilter implements Runnab
 
     @Override
     public void run() {
+        processQueue();
+    }
+
+    public boolean processQueue() {
+        boolean processed = false;
         try {
             Entry entry;
             while ((entry = queue.poll()) != null) {
+                processed = true;
                 learn(entry.result, entry.context);
             }
         } catch (Exception e) {
             log.error("aborting learning due to exception", e);
         }
+        return processed;
     }
 
     private class Entry {

--- a/eblocker-icapserver/src/test/java/org/eblocker/server/icap/filter/FilterManagerTest.java
+++ b/eblocker-icapserver/src/test/java/org/eblocker/server/icap/filter/FilterManagerTest.java
@@ -51,6 +51,7 @@ import static org.junit.Assert.assertEquals;
 public class FilterManagerTest {
     private static final String FILTER_NAME = "test-filter";
     private static final String TRACKER_URL = "http://0tracker.com/";
+    private static final String LEARNED_URL = "http://www.example.org/ads.example.test/script.js";
     private static final String FILE_SUFFIX = ".json.enc";
 
     private List<FilterStoreConfiguration> defaultConfigurations;
@@ -184,6 +185,28 @@ public class FilterManagerTest {
     }
 
     @Test
+    public void testAddedAsynchronousFilterPersistsLearnedMatchesAfterRestart() throws Exception {
+        objectMapper.writeValue(defaultConfigurationsPath.toFile(), Collections.emptyList());
+
+        FilterManager manager = createManager();
+        writeCsvFilterToCache("ads.example.test");
+        FilterStoreConfiguration newConfiguration = new FilterStoreConfiguration(null, "test", Category.ADS, false, System.currentTimeMillis(), new String[]{ resourceFile.toString() }, FilterLearningMode.ASYNCHRONOUS, FilterDefinitionFormat.CSV, true,
+                new String[0], true);
+        FilterStoreConfiguration savedConfiguration = manager.addFilter(newConfiguration);
+
+        assertEquals(Decision.NO_DECISION, decisionForURL(manager.getFilter(Category.ADS), LEARNED_URL));
+        manager.getAsynchronousLearnersUpdater().run();
+        assertEquals(Decision.BLOCK, decisionForURL(manager.getFilter(Category.ADS), LEARNED_URL));
+
+        Mockito.when(dataSource.getAll(FilterStoreConfiguration.class)).thenReturn(Collections.singletonList(savedConfiguration));
+        FilterManager restartedManager = createManager();
+
+        assertEquals(Decision.BLOCK, decisionForURL(restartedManager.getFilter(Category.ADS), LEARNED_URL));
+        Assert.assertFalse(Files.exists(cacheDirectory.resolve("null" + FILE_SUFFIX)));
+        Assert.assertTrue(Files.exists(cacheDirectory.resolve(savedConfiguration.getId() + FILE_SUFFIX)));
+    }
+
+    @Test
     public void testRemoveFilter() throws IOException, CryptoException {
         // create single non-default config
         objectMapper.writeValue(defaultConfigurationsPath.toFile(), Collections.emptyList());
@@ -254,5 +277,10 @@ public class FilterManagerTest {
         SimpleResource source = new SimpleResource("classpath:test-data/filter/easyprivacy.txt");
         String list = ResourceHandler.load(source);
         Files.write(resourceFile, list.getBytes(Charset.forName("UTF-8")));
+    }
+
+    private void writeCsvFilterToCache(String pattern) throws IOException {
+        String filter = "BLOCK\tMEDIUM\t-\tCONTAINS\t" + pattern + "\t-\t-\t-\n";
+        Files.write(resourceFile, filter.getBytes(Charset.forName("UTF-8")));
     }
 }


### PR DESCRIPTION
## Summary
- create newly added filter stores only after the persisted configuration id is available
- persist asynchronous learning results immediately after the learner queue processed entries
- add a regression test for learned pattern-filter matches surviving the first restart

Fixes #428

## Test Plan
- [x] `mvn -pl eblocker-icapserver -Dtest=FilterManagerTest#testAddedAsynchronousFilterPersistsLearnedMatchesAfterRestart test`
- [x] `mvn -pl eblocker-icapserver -Dtest=FilterManagerTest,AsynchronousLearningFilterTest test`
- [x] `mvn -pl eblocker-icapserver -Dtest='*,!NetworkInterfaceAliasesTest' test`

Note: `mvn -pl eblocker-icapserver test` fails in this VM only in `NetworkInterfaceAliasesTest` because the VM's primary interface is `ens18` and the test only accepts patterns like `eth\\d+`, `en\\d+`, `enp\\ds\\d+`. Excluding that environment-dependent test, the module suite passes.
