### PR TITLE
fix: clean up user custom domain filters

### DIFF
--- a/eblocker-icapserver/src/main/java/org/eblocker/server/http/service/CustomDomainFilterConfigService.java
+++ b/eblocker-icapserver/src/main/java/org/eblocker/server/http/service/CustomDomainFilterConfigService.java
@@ -46,6 +46,17 @@ public class CustomDomainFilterConfigService {
                                            UserService userService) {
         this.filterListsService = filterListsService;
         this.userService = userService;
+        this.userService.addListener(new UserService.UserChangeListener() {
+            @Override
+            public void onChange(UserModule user) {
+                // No action required for regular user updates.
+            }
+
+            @Override
+            public void onDelete(UserModule user) {
+                deleteCustomDomainFilters(user);
+            }
+        });
     }
 
     public CustomDomainFilterConfig getCustomDomainFilterConfig(int userId) {
@@ -82,11 +93,20 @@ public class CustomDomainFilterConfigService {
         return new HashSet<>(filterListsService.getFilterListDomains(listId));
     }
 
+    private void deleteCustomDomainFilters(UserModule user) {
+        deleteFilterList(user.getCustomBlacklistId());
+        deleteFilterList(user.getCustomWhitelistId());
+    }
+
+    private void deleteFilterList(Integer id) {
+        if (id != null) {
+            filterListsService.deleteFilterList(id);
+        }
+    }
+
     private Integer updateDnsFilter(Integer id, int userId, String type, Set<String> domains) {
         if (domains.isEmpty()) {
-            if (id != null) {
-                filterListsService.deleteFilterList(id);
-            }
+            deleteFilterList(id);
             return null;
         }
 

--- a/eblocker-icapserver/src/main/java/org/eblocker/server/http/service/UserService.java
+++ b/eblocker-icapserver/src/main/java/org/eblocker/server/http/service/UserService.java
@@ -176,15 +176,20 @@ public class UserService {
         if (userId == null) {
             throw new BadRequestException("Cannot delete user without valid user id.");
         }
+        UserModule user = cache.get(userId);
         // make sure it is not a system user
-        if (cache.get(userId).isSystem()) {
+        if (user.isSystem()) {
             throw new BadRequestException("Cannot delete user " + userId + ", because it is a system user.");
         }
 
         // may remove parental control card and update all parent's dashboardColumnView
         checkAndUpdateParentalControlData(userId, null, null);
 
-        return doDelete(userId);
+        boolean deleted = doDelete(userId);
+        if (deleted) {
+            notifyDeleteListeners(user);
+        }
+        return deleted;
     }
 
     private UserModule updateSystemUser(Integer id,
@@ -448,6 +453,10 @@ public class UserService {
         listeners.forEach(listener -> listener.onChange(user));
     }
 
+    private void notifyDeleteListeners(UserModule user) {
+        listeners.forEach(listener -> listener.onDelete(user));
+    }
+
     private void updateCacheEntries(List<UserModule> users) {
         users.forEach(this::cacheUser);
     }
@@ -601,6 +610,9 @@ public class UserService {
 
     public interface UserChangeListener {
         void onChange(UserModule user);
+
+        default void onDelete(UserModule user) {
+        }
     }
 
     private UserModule findUpdatableUser(Integer id) {

--- a/eblocker-icapserver/src/test/java/org/eblocker/server/http/service/CustomDomainFilterConfigServiceTest.java
+++ b/eblocker-icapserver/src/test/java/org/eblocker/server/http/service/CustomDomainFilterConfigServiceTest.java
@@ -94,6 +94,17 @@ public class CustomDomainFilterConfigServiceTest {
     }
 
     @Test
+    public void deleteUserDeletesCustomDomainFilters() {
+        ArgumentCaptor<UserService.UserChangeListener> listenerCaptor = ArgumentCaptor.forClass(UserService.UserChangeListener.class);
+        Mockito.verify(userService).addListener(listenerCaptor.capture());
+
+        listenerCaptor.getValue().onDelete(mockUser(3, 2, 1));
+
+        Mockito.verify(filterListsService).deleteFilterList(2);
+        Mockito.verify(filterListsService).deleteFilterList(1);
+    }
+
+    @Test
     public void setCustomDomainFilterUpdate() {
         CustomDomainFilterConfig savedFilter = customDomainFilterConfigService
                 .setCustomDomainFilterConfig(3, new CustomDomainFilterConfig(Sets.newHashSet("etracker.com", "google.com"), Sets.newHashSet("eblocker.com", "xkcd.com")));

--- a/eblocker-icapserver/src/test/java/org/eblocker/server/http/service/UserServiceTest.java
+++ b/eblocker-icapserver/src/test/java/org/eblocker/server/http/service/UserServiceTest.java
@@ -31,6 +31,7 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.AdditionalAnswers;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 import org.restexpress.exception.BadRequestException;
 
@@ -144,6 +145,13 @@ public class UserServiceTest {
     }
 
     private UserModule createMockUser(int userId, String userName,
+                                      int associatedProfileId, Integer customBlacklistId,
+                                      Integer customWhitelistId) {
+        return new UserModule(userId, associatedProfileId, userName, userName, null, null,
+                false, null, Collections.emptyMap(), null, customBlacklistId, customWhitelistId);
+    }
+
+    private UserModule createMockUser(int userId, String userName,
                                       int associatedProfileId, boolean hasPin, byte[] pin) {
         return new UserModule(userId, associatedProfileId, userName, userName, null, null,
                 false, pin, Collections.emptyMap(), null, null, null);
@@ -156,7 +164,7 @@ public class UserServiceTest {
     private UserModule copyUser(UserModule user) {
         return new UserModule(user.getId(), user.getAssociatedProfileId(),
                 user.getName(), user.getNameKey(), null, user.getUserRole(), user.isSystem(), user.getPin(),
-                new HashMap<>(user.getWhiteListConfigByDomains()), null, null, null);
+                new HashMap<>(user.getWhiteListConfigByDomains()), null, user.getCustomBlacklistId(), user.getCustomWhitelistId());
     }
 
     @Test
@@ -183,6 +191,21 @@ public class UserServiceTest {
                 Assert.fail();
             }
         }
+    }
+
+    @Test
+    public void testDeleteUserNotifiesListenersWithCustomFilterIds() {
+        UserModule deletedUser = createMockUser(100, "alice", 100, 1000, 1001);
+        users.set(1, deletedUser);
+        userService.refresh();
+
+        Assert.assertTrue(userService.deleteUser(deletedUser.getId()));
+
+        ArgumentCaptor<UserModule> deletedUserCaptor = ArgumentCaptor.forClass(UserModule.class);
+        Mockito.verify(listener).onDelete(deletedUserCaptor.capture());
+        Assert.assertEquals(deletedUser.getId(), deletedUserCaptor.getValue().getId());
+        Assert.assertEquals(deletedUser.getCustomBlacklistId(), deletedUserCaptor.getValue().getCustomBlacklistId());
+        Assert.assertEquals(deletedUser.getCustomWhitelistId(), deletedUserCaptor.getValue().getCustomWhitelistId());
     }
 
     @Test


### PR DESCRIPTION
## Summary
- Adds a user-delete notification hook so services can react after a user is actually deleted.
- Registers `CustomDomainFilterConfigService` for delete events and removes the deleted user's custom blacklist/whitelist filter lists.
- Reuses the existing filter-list deletion path so Redis metadata and generated custom filter files are cleaned up consistently.

Fixes #423

## Tests
- `mvn -pl eblocker-icapserver -Dtest=UserServiceTest#testDeleteUserNotifiesListenersWithCustomFilterIds,CustomDomainFilterConfigServiceTest#deleteUserDeletesCustomDomainFilters test`
- `mvn -pl eblocker-icapserver -Dtest=UserServiceTest,CustomDomainFilterConfigServiceTest test`
- `mvn -pl eblocker-icapserver -Dtest='*,!NetworkInterfaceAliasesTest' test` (2040 tests, 0 failures, 0 errors, 6 skipped)
- `git diff --check`
