### PR TITLE
fix: warn about fixed IP for devices with multiple IPv4 addresses

### DIFF
--- a/eblocker-ui/src/locale/lang-settings-de.json
+++ b/eblocker-ui/src/locale/lang-settings-de.json
@@ -484,6 +484,7 @@
                     "LABEL_RESET_DEVICE": "Gerät zurücksetzen",
                     "LABEL_VENDOR": "Hersteller",
                     "LABEL_VENDOR_PRIVATE_MAC": "Unbekannt (private MAC-Adresse)",
+                    "WARNING_FIXED_IP_MULTIPLE_IPV4": "Dieses Gerät hat aktuell mehrere IPv4-Adressen. Bei aktivierter fester IP-Zuweisung vergibt der DHCP-Server des eBlockers eine Adresse an die gemeinsame Hardware-Adresse (MAC). Wenn mehrere Geräte diese MAC-Adresse verwenden, können sie um dieselbe IP-Adresse konkurrieren. Deaktiviere die feste IP-Zuweisung für dieses Gerät, falls IP-Adresskonflikte auftreten.",
                     "TOOLTIP": {
                         "EDIT_DEVICE": "Gerätenamen ändern"
                     }

--- a/eblocker-ui/src/locale/lang-settings-en.json
+++ b/eblocker-ui/src/locale/lang-settings-en.json
@@ -484,6 +484,7 @@
                     "LABEL_RESET_DEVICE" : "Reset device",
                     "LABEL_VENDOR" : "Vendor",
                     "LABEL_VENDOR_PRIVATE_MAC" : "Unknown (private MAC address)",
+                    "WARNING_FIXED_IP_MULTIPLE_IPV4" : "This device currently has multiple IPv4 addresses. With fixed IP assignment enabled, eBlocker's DHCP server assigns one address to the shared hardware address (MAC). If several devices use this MAC address, they may compete for the same IP address. Disable fixed IP assignment for this device if you notice IP address conflicts.",
                     "TOOLTIP" : {
                         "EDIT_DEVICE" : "Edit device name."
                     }

--- a/eblocker-ui/src/settings/app/components/devices/list/devices-details-device.component.html
+++ b/eblocker-ui/src/settings/app/components/devices/list/devices-details-device.component.html
@@ -102,6 +102,18 @@
             <md-switch md-theme="eBlockerThemeSwitch" layout-padding layout="row" layout-align="start center" ng-model="vm.device.ipAddressFixed" class="md-primary switch-word-break" ng-change="vm.onChange(vm.device)">
                 {{ vm.device.ipAddressFixed ? 'ADMINCONSOLE.DEVICES_LIST.DETAILS.GENERAL.LABEL_IP_ADDRESS_FIXED' : 'ADMINCONSOLE.DEVICES_LIST.DETAILS.GENERAL.LABEL_IP_ADDRESS_NOT_FIXED' | translate }}
             </md-switch>
+            <div ng-if="vm.showFixedIpMultipleAddressesWarning()"
+                 class="alert-box"
+                 layout="row"
+                 layout-align="start center"
+                 style="max-width: 650px; margin-left: 16px; margin-bottom: 12px; padding: 8px;">
+                <div style="margin-right: 16px;">
+                    <md-icon class="content-warn" md-svg-src="/img/icons/ic_warning.svg"></md-icon>
+                </div>
+                <div layout="column">
+                    <p translate="ADMINCONSOLE.DEVICES_LIST.DETAILS.GENERAL.WARNING_FIXED_IP_MULTIPLE_IPV4"></p>
+                </div>
+            </div>
         </div>
         <!-- Reset button -->
         <md-divider style="width: 100%; margin-top: 12px;"></md-divider>

--- a/eblocker-ui/src/settings/app/components/devices/list/devices-details.component.js
+++ b/eblocker-ui/src/settings/app/components/devices/list/devices-details.component.js
@@ -59,6 +59,7 @@ function Controller(logger, $stateParams, $window, $interval, $timeout, $q, $tra
     vm.updateCustomUserAgent = updateCustomUserAgent;
     vm.updateMessageSeverity = updateMessageSeverity;
     vm.onChangeHttps = onChangeHttps;
+    vm.showFixedIpMultipleAddressesWarning = showFixedIpMultipleAddressesWarning;
 
     vm.backState = STATES.DEVICES;
     vm.stateParams = $stateParams;
@@ -312,6 +313,22 @@ function Controller(logger, $stateParams, $window, $interval, $timeout, $q, $tra
         }, function error(response) {
             logger.error('unable to get dhcp state ', response);
         });
+    }
+
+    function showFixedIpMultipleAddressesWarning() {
+        return vm.dhcpActive === true &&
+            angular.isObject(vm.device) &&
+            vm.device.ipAddressFixed === true &&
+            hasMultipleIpv4Addresses(vm.device.ipAddresses);
+    }
+
+    function hasMultipleIpv4Addresses(ipAddresses) {
+        if (!angular.isArray(ipAddresses)) {
+            return false;
+        }
+        return ipAddresses.filter(function(ipAddress) {
+            return IpUtilsService.isIpv4Address(ipAddress);
+        }).length > 1;
     }
 
     function logoutOperatingUser(device) {

--- a/eblocker-ui/src/settings/app/components/devices/list/devices-details.component.spec.js
+++ b/eblocker-ui/src/settings/app/components/devices/list/devices-details.component.spec.js
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2020 eBlocker Open Source UG (haftungsbeschraenkt)
+ *
+ * Licensed under the EUPL, Version 1.2 or - as soon they will be
+ * approved by the European Commission - subsequent versions of the EUPL
+ * (the "License"); You may not use this work except in compliance with
+ * the License. You may obtain a copy of the License at:
+ *
+ *   https://joinup.ec.europa.eu/page/eupl-text-11-12
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+import 'angular-mocks';
+
+describe('App settings; Devices-Details component controller', function() {
+    beforeEach(angular.mock.module('template.settings.app'));
+    beforeEach(angular.mock.module('eblocker.adminconsole'));
+
+    let ctrl, $componentController;
+
+    beforeEach(angular.mock.module(function($translateProvider) {
+        // Workaround angular-translate issue:
+        // https://angular-translate.github.io/docs/#/guide/22_unit-testing-with-angular-translate
+        $translateProvider.translations('en', {});
+    }));
+
+    beforeEach(inject(function(_$componentController_) {
+        $componentController = _$componentController_;
+        ctrl = $componentController('devicesDetailsComponent', {
+            $stateParams: {},
+            STATES: {
+                DEVICES: 'devices'
+            },
+            logger: {
+                error: angular.noop,
+                warn: angular.noop
+            }
+        }, {
+            users: [],
+            vpnHomeCertificates: []
+        });
+    }));
+
+    describe('initially', function() {
+        it('should create a controller instance', function() {
+            expect(angular.isDefined(ctrl)).toBe(true);
+        });
+    });
+
+    describe('showFixedIpMultipleAddressesWarning', function() {
+        function setDevice(ipAddresses, ipAddressFixed, dhcpActive) {
+            ctrl.dhcpActive = dhcpActive;
+            ctrl.device = {
+                ipAddresses: ipAddresses,
+                ipAddressFixed: ipAddressFixed
+            };
+        }
+
+        it('should warn when eBlocker runs DHCP and a fixed-IP device has multiple IPv4 addresses', function() {
+            setDevice(['192.168.1.20', '192.168.1.21'], true, true);
+
+            expect(ctrl.showFixedIpMultipleAddressesWarning()).toBe(true);
+        });
+
+        it('should not warn when DHCP is inactive', function() {
+            setDevice(['192.168.1.20', '192.168.1.21'], true, false);
+
+            expect(ctrl.showFixedIpMultipleAddressesWarning()).toBe(false);
+        });
+
+        it('should not warn when fixed IP assignment is disabled', function() {
+            setDevice(['192.168.1.20', '192.168.1.21'], false, true);
+
+            expect(ctrl.showFixedIpMultipleAddressesWarning()).toBe(false);
+        });
+
+        it('should not warn for a single IPv4 address', function() {
+            setDevice(['192.168.1.20'], true, true);
+
+            expect(ctrl.showFixedIpMultipleAddressesWarning()).toBe(false);
+        });
+
+        it('should only count IPv4 addresses', function() {
+            setDevice(['192.168.1.20', 'fe80::1', 'fe80::2'], true, true);
+
+            expect(ctrl.showFixedIpMultipleAddressesWarning()).toBe(false);
+        });
+    });
+});


### PR DESCRIPTION
## Summary
- show a warning on the device details page when eBlocker DHCP is active, fixed IP assignment is enabled, and the device has multiple IPv4 addresses
- count only IPv4 addresses for the warning condition
- add German and English warning text
- add regression coverage for the warning predicate

## Test Plan
- `OPENSSL_CONF=/dev/null npm test -- --single-run` (284 SUCCESS)
- `OPENSSL_CONF=/dev/null npx gulp start-dev`
- `OPENSSL_CONF=/dev/null npx gulp build` (includes vet and 284 SUCCESS)

Closes #422
