### PR TITLE
fix: normalize illegal device enabled paused state

### DIFF
--- a/eblocker-icapserver/src/main/java/org/eblocker/server/http/service/DeviceService.java
+++ b/eblocker-icapserver/src/main/java/org/eblocker/server/http/service/DeviceService.java
@@ -127,6 +127,8 @@ public class DeviceService {
                     + device.getAssignedUser());
         }
 
+        normalizeEnabledPausedState(device);
+
         // handle icon visibility (if in auto mode) depending on device and global SSL status
         device = updateIconStatus(device);
 
@@ -253,7 +255,21 @@ public class DeviceService {
     }
 
     private void updateCacheEntries(Set<Device> devices) {
-        devices.forEach(this::cacheDevice);
+        devices.forEach(device -> {
+            if (normalizeEnabledPausedState(device)) {
+                datasource.save(device);
+            }
+            cacheDevice(device);
+        });
+    }
+
+    private boolean normalizeEnabledPausedState(Device device) {
+        if (device.isEnabled() && device.isPaused()) {
+            log.warn("Device {} has illegal enabled+paused state; clearing paused flag", device.getId());
+            device.setPaused(false);
+            return true;
+        }
+        return false;
     }
 
     /**

--- a/eblocker-icapserver/src/test/java/org/eblocker/server/http/service/DeviceServiceTest.java
+++ b/eblocker-icapserver/src/test/java/org/eblocker/server/http/service/DeviceServiceTest.java
@@ -333,6 +333,24 @@ public class DeviceServiceTest {
     }
 
     @Test
+    public void testUpdateClearsPausedFlagForEnabledDevice() {
+        // setup updated device with illegal enabled+paused state
+        Device device = createMockDevice(devices.get(0).getId(), "192.168.3.1", devices.get(0).getOperatingUser(), true, true, false, false);
+        device.setEnabled(true);
+        device.setPaused(true);
+
+        // update device
+        deviceService.updateDevice(device);
+
+        // check it has been normalized before being cached and stored
+        Device retrievedDevice = deviceService.getDeviceById(device.getId());
+        Assert.assertTrue(retrievedDevice.isEnabled());
+        Assert.assertFalse(retrievedDevice.isPaused());
+        Mockito.verify(dataSource).save(Mockito.<Device>argThat(savedDevice ->
+                savedDevice.getId().equals(device.getId()) && savedDevice.isEnabled() && !savedDevice.isPaused()));
+    }
+
+    @Test
     public void testUpdateOperatingUserNotExisting() {
         // ensure original device is in cache
         Device device = devices.get(0);
@@ -411,6 +429,22 @@ public class DeviceServiceTest {
 
         // check listener has been notified
         Mockito.verify(listener).onChange(retrievedDevice);
+    }
+
+    @Test
+    public void testRefreshClearsPausedFlagForEnabledDevice() {
+        Device device = devices.get(0);
+        device.setEnabled(true);
+        device.setPaused(true);
+        Mockito.clearInvocations(dataSource);
+
+        deviceService.refresh();
+
+        Device retrievedDevice = deviceService.getDeviceById(device.getId());
+        Assert.assertTrue(retrievedDevice.isEnabled());
+        Assert.assertFalse(retrievedDevice.isPaused());
+        Mockito.verify(dataSource).save(Mockito.<Device>argThat(savedDevice ->
+                savedDevice.getId().equals(device.getId()) && savedDevice.isEnabled() && !savedDevice.isPaused()));
     }
 
     @Test
@@ -519,6 +553,8 @@ public class DeviceServiceTest {
         copy.setIpAddresses(device.getIpAddresses());
         copy.setAssignedUser(device.getAssignedUser());
         copy.setOperatingUser(device.getOperatingUser());
+        copy.setEnabled(device.isEnabled());
+        copy.setPaused(device.isPaused());
         copy.setOnline(device.isOnline());
         copy.setIpAddressFixed(device.isIpAddressFixed());
         copy.setIsGateway(device.isGateway());


### PR DESCRIPTION
## Summary
- Normalize illegal `Device` state `enabled=true && paused=true` before persisting updates.
- Repair already stored illegal states during `DeviceService.refresh()` before caching them.
- Add regression tests for both update and refresh paths.

## Test Plan
- [x] RED: `mvn -pl eblocker-icapserver -Dtest=DeviceServiceTest#testUpdateClearsPausedFlagForEnabledDevice test` failed before the fix on `assertFalse(retrievedDevice.isPaused())`.
- [x] `mvn -pl eblocker-icapserver -Dtest=DeviceServiceTest#testUpdateClearsPausedFlagForEnabledDevice test`
- [x] `mvn -pl eblocker-icapserver -Dtest=DeviceServiceTest,DeviceControllerImplTest,PauseDeviceControllerImplTest test`
- [x] `mvn -pl eblocker-icapserver -Dtest='!org.eblocker.server.common.network.unix.NetworkInterfaceAliasesTest' test` — 2040 tests, 0 failures/errors, 6 skipped.
- [x] `mvn -pl eblocker-icapserver test` — attempted; 2044 tests run, only `NetworkInterfaceAliasesTest` failed because this environment exposes `ens18` / altname `enp6s18`, while the test expects names matching `eth\\d+`, `en\\d+`, or `enp\\ds\\d+`.

Closes #418
