### PR TITLE
feat: make admin session timeout configurable

### DIFF
--- a/eblocker-icapserver/src/main/java/org/eblocker/server/common/data/AdminConsoleSettings.java
+++ b/eblocker-icapserver/src/main/java/org/eblocker/server/common/data/AdminConsoleSettings.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2020 eBlocker Open Source UG (haftungsbeschraenkt)
+ *
+ * Licensed under the EUPL, Version 1.2 or - as soon they will be
+ * approved by the European Commission - subsequent versions of the EUPL
+ * (the "License"); You may not use this work except in compliance with
+ * the License. You may obtain a copy of the License at:
+ *
+ *   https://joinup.ec.europa.eu/page/eupl-text-11-12
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+package org.eblocker.server.common.data;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class AdminConsoleSettings {
+    public static final int DEFAULT_SESSION_TIMEOUT_SECONDS = 20 * 60;
+
+    private int sessionTimeoutSeconds;
+
+    public AdminConsoleSettings() {
+        this(DEFAULT_SESSION_TIMEOUT_SECONDS);
+    }
+
+    @JsonCreator
+    public AdminConsoleSettings(@JsonProperty("sessionTimeoutSeconds") Integer sessionTimeoutSeconds) {
+        this.sessionTimeoutSeconds = sessionTimeoutSeconds == null ? DEFAULT_SESSION_TIMEOUT_SECONDS : sessionTimeoutSeconds;
+    }
+
+    public int getSessionTimeoutSeconds() {
+        return sessionTimeoutSeconds;
+    }
+
+    public void setSessionTimeoutSeconds(int sessionTimeoutSeconds) {
+        this.sessionTimeoutSeconds = sessionTimeoutSeconds;
+    }
+}

--- a/eblocker-icapserver/src/main/java/org/eblocker/server/http/controller/AuthenticationController.java
+++ b/eblocker-icapserver/src/main/java/org/eblocker/server/http/controller/AuthenticationController.java
@@ -18,6 +18,7 @@ package org.eblocker.server.http.controller;
 
 import org.eblocker.server.http.security.JsonWebToken;
 import org.eblocker.server.http.security.PasswordResetToken;
+import org.eblocker.server.common.data.AdminConsoleSettings;
 import org.restexpress.Request;
 import org.restexpress.Response;
 
@@ -39,6 +40,10 @@ public interface AuthenticationController {
     PasswordResetToken initiateReset(Request request, Response response);
 
     void executeReset(Request request, Response response);
+
+    AdminConsoleSettings getAdminConsoleSettings(Request request, Response response);
+
+    AdminConsoleSettings setAdminConsoleSettings(Request request, Response response);
 
     void cancelReset(Request request, Response response);
 

--- a/eblocker-icapserver/src/main/java/org/eblocker/server/http/controller/impl/AuthenticationControllerImpl.java
+++ b/eblocker-icapserver/src/main/java/org/eblocker/server/http/controller/impl/AuthenticationControllerImpl.java
@@ -19,6 +19,7 @@ package org.eblocker.server.http.controller.impl;
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
 import io.netty.handler.codec.http.HttpResponseStatus;
+import org.eblocker.server.common.data.AdminConsoleSettings;
 import org.eblocker.server.common.data.IpAddress;
 import org.eblocker.server.common.page.PageContextStore;
 import org.eblocker.server.common.session.SessionStore;
@@ -114,6 +115,16 @@ public class AuthenticationControllerImpl extends SessionContextController imple
     public void executeReset(Request request, Response response) {
         IpAddress ipAddress = getSession(request).getIp();
         securityService.executeReset(request.getBodyAs(PasswordResetToken.class), ipAddress);
+    }
+
+    @Override
+    public AdminConsoleSettings getAdminConsoleSettings(Request request, Response response) {
+        return securityService.getAdminConsoleSettings();
+    }
+
+    @Override
+    public AdminConsoleSettings setAdminConsoleSettings(Request request, Response response) {
+        return securityService.setAdminConsoleSettings(request.getBodyAs(AdminConsoleSettings.class));
     }
 
     @Override

--- a/eblocker-icapserver/src/main/java/org/eblocker/server/http/security/SecurityService.java
+++ b/eblocker-icapserver/src/main/java/org/eblocker/server/http/security/SecurityService.java
@@ -20,6 +20,7 @@ import com.google.inject.Inject;
 import com.google.inject.Singleton;
 import com.google.inject.name.Named;
 import org.eblocker.registration.ProductFeature;
+import org.eblocker.server.common.data.AdminConsoleSettings;
 import org.eblocker.server.common.data.DataSource;
 import org.eblocker.server.common.data.Device;
 import org.eblocker.server.common.data.IpAddress;
@@ -218,6 +219,21 @@ public class SecurityService {
     public long passwordEntryInSeconds(IpAddress ip) {
         Instant now = clock.instant();
         return Duration.between(now, this.nextPasswordEntryPermittedAt.getOrDefault(ip, now)).getSeconds();
+    }
+
+    public AdminConsoleSettings getAdminConsoleSettings() {
+        AdminConsoleSettings settings = dataSource.get(AdminConsoleSettings.class);
+        if (settings == null || settings.getSessionTimeoutSeconds() < 0) {
+            return new AdminConsoleSettings();
+        }
+        return settings;
+    }
+
+    public AdminConsoleSettings setAdminConsoleSettings(AdminConsoleSettings settings) {
+        if (settings == null || settings.getSessionTimeoutSeconds() < 0) {
+            throw new BadRequestException("error.adminConsoleSettings.invalidSessionTimeout");
+        }
+        return dataSource.save(settings);
     }
 
     public boolean isPasswordRequired() {

--- a/eblocker-icapserver/src/main/java/org/eblocker/server/http/server/EblockerHttpsServer.java
+++ b/eblocker-icapserver/src/main/java/org/eblocker/server/http/server/EblockerHttpsServer.java
@@ -775,6 +775,17 @@ public class EblockerHttpsServer implements Preprocessor {
                 .name("adminconsole.authentication.renew.route");
 
         server
+                .uri("/api/adminconsole/authentication/settings", authenticationController)
+                .action("getAdminConsoleSettings", HttpMethod.GET)
+                .name("public.adminconsole.authentication.settings.get.route")
+                .flag(SecurityProcessor.NO_AUTHENTICATION_REQUIRED);
+
+        server
+                .uri("/api/adminconsole/authentication/settings", authenticationController)
+                .action("setAdminConsoleSettings", HttpMethod.PUT)
+                .name("adminconsole.authentication.settings.put.route");
+
+        server
                 .uri("/api/adminconsole/authentication/enable", authenticationController)
                 .action("enable", HttpMethod.POST)
                 .name("adminconsole.authentication.enable.route");

--- a/eblocker-icapserver/src/test/java/org/eblocker/server/http/security/SecurityServiceTest.java
+++ b/eblocker-icapserver/src/test/java/org/eblocker/server/http/security/SecurityServiceTest.java
@@ -16,6 +16,7 @@
  */
 package org.eblocker.server.http.security;
 
+import org.eblocker.server.common.data.AdminConsoleSettings;
 import org.eblocker.server.common.data.IpAddress;
 import org.eblocker.server.common.data.events.EventLogger;
 import org.eblocker.server.common.data.events.EventType;
@@ -34,6 +35,7 @@ import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.MockitoJUnit;
 import org.mockito.junit.MockitoRule;
+import org.restexpress.exception.BadRequestException;
 import org.restexpress.exception.UnauthorizedException;
 
 import java.io.IOException;
@@ -327,6 +329,31 @@ public class SecurityServiceTest extends EmbeddedRedisServiceTestBase {
             // Any exception is not accepted
             fail("Expected no UnauthorizedException");
         }
+    }
+
+    @Test
+    public void testAdminConsoleSettingsDefaultSessionTimeout() {
+        SecurityService securityService = createSecurityService();
+
+        AdminConsoleSettings settings = securityService.getAdminConsoleSettings();
+
+        assertEquals(AdminConsoleSettings.DEFAULT_SESSION_TIMEOUT_SECONDS, settings.getSessionTimeoutSeconds());
+    }
+
+    @Test
+    public void testAdminConsoleSettingsCanDisableSessionTimeout() {
+        SecurityService securityService = createSecurityService();
+
+        securityService.setAdminConsoleSettings(new AdminConsoleSettings(0));
+
+        assertEquals(0, securityService.getAdminConsoleSettings().getSessionTimeoutSeconds());
+    }
+
+    @Test(expected = BadRequestException.class)
+    public void testAdminConsoleSettingsRejectsNegativeSessionTimeout() {
+        SecurityService securityService = createSecurityService();
+
+        securityService.setAdminConsoleSettings(new AdminConsoleSettings(-1));
     }
 
     @Test

--- a/eblocker-ui/src/locale/lang-settings-de.json
+++ b/eblocker-ui/src/locale/lang-settings-de.json
@@ -136,17 +136,23 @@
         },
         "ADMIN_PASSWORD": {
             "ACTION": {
-                "CHANGE_PASSWORD": "Passwort ändern"
+                "CHANGE_PASSWORD": "Passwort ändern",
+                "SAVE": "Speichern"
             },
             "LABEL": "Admin-Passwort",
             "LABEL_PASSWORD_DISABLED": "Administratorpasswort ist deaktiviert",
             "LABEL_PASSWORD_ENABLED": "Administratorpasswort ist aktiviert",
+            "LABEL_SESSION_TIMEOUT": "Sitzungs-Timeout",
             "NOTIFICATION": {
                 "INFO_PASSWORD_CHANGED": "Passwort erfolgreich geändert.",
                 "INFO_PASSWORD_DISABLED": "Passwort erfolgreich entfernt.",
-                "INFO_PASSWORD_ENABLED": "Passwort erfolgreich eingerichtet."
+                "INFO_PASSWORD_ENABLED": "Passwort erfolgreich eingerichtet.",
+                "INFO_SESSION_TIMEOUT_CHANGED": "Sitzungs-Timeout erfolgreich geändert.",
+                "ERROR_SESSION_TIMEOUT_CHANGED": "Der Sitzungs-Timeout konnte nicht geändert werden."
             },
-            "NO_PASSWORD_TEXT": "Jeder mit Zugang zu deinem lokalen Netzwerk kann die eBlocker Einstellungen einsehen und ändern."
+            "NO_PASSWORD_TEXT": "Jeder mit Zugang zu deinem lokalen Netzwerk kann die eBlocker Einstellungen einsehen und ändern.",
+            "SESSION_TIMEOUT_MINUTES": "Minuten",
+            "SESSION_TIMEOUT_TEXT": "Die Admin-Konsole meldet dich nach dieser Anzahl Minuten ohne Benutzerinteraktion automatisch ab. Gib 0 ein, um die automatische Abmeldung zu deaktivieren."
         },
         "ADVANCED": {
             "LABEL": "Fortgeschritten"

--- a/eblocker-ui/src/locale/lang-settings-en.json
+++ b/eblocker-ui/src/locale/lang-settings-en.json
@@ -136,17 +136,23 @@
         },
         "ADMIN_PASSWORD" : {
             "ACTION" : {
-                "CHANGE_PASSWORD" : "Change password"
+                "CHANGE_PASSWORD" : "Change password",
+                "SAVE" : "Save"
             },
             "LABEL" : "Admin Password",
             "LABEL_PASSWORD_DISABLED" : "Administrator password is disabled",
             "LABEL_PASSWORD_ENABLED" : "Administrator password is enabled",
+            "LABEL_SESSION_TIMEOUT" : "Session timeout",
             "NOTIFICATION" : {
                 "INFO_PASSWORD_CHANGED" : "Successfully changed password",
                 "INFO_PASSWORD_DISABLED" : "Successfully disabled password",
-                "INFO_PASSWORD_ENABLED" : "Successfully enabled password"
+                "INFO_PASSWORD_ENABLED" : "Successfully enabled password",
+                "INFO_SESSION_TIMEOUT_CHANGED" : "Successfully changed session timeout",
+                "ERROR_SESSION_TIMEOUT_CHANGED" : "The session timeout could not be changed."
             },
-            "NO_PASSWORD_TEXT" : "Anyone with access to your local network can see and modify eBlocker settings!"
+            "NO_PASSWORD_TEXT" : "Anyone with access to your local network can see and modify eBlocker settings!",
+            "SESSION_TIMEOUT_MINUTES" : "Minutes",
+            "SESSION_TIMEOUT_TEXT" : "The admin console logs out automatically after this many minutes without user interaction. Enter 0 to disable automatic logout."
         },
         "ADVANCED" : {
             "LABEL" : "Advanced"

--- a/eblocker-ui/src/settings/app/components/system/adminPassword/admin-password.component.html
+++ b/eblocker-ui/src/settings/app/components/system/adminPassword/admin-password.component.html
@@ -24,6 +24,26 @@
                     ng-click="vm.changePassword()">
                 {{'ADMINCONSOLE.ADMIN_PASSWORD.ACTION.CHANGE_PASSWORD' | translate}}
             </md-button>
+
+            <md-divider layout-margin></md-divider>
+
+            <div layout="column" class="session-timeout-settings">
+                <span class="md-subhead">{{'ADMINCONSOLE.ADMIN_PASSWORD.LABEL_SESSION_TIMEOUT' | translate}}</span>
+                <p>{{'ADMINCONSOLE.ADMIN_PASSWORD.SESSION_TIMEOUT_TEXT' | translate}}</p>
+                <div layout-gt-sm="row" layout="column" layout-align-gt-sm="start center">
+                    <md-input-container>
+                        <label>{{'ADMINCONSOLE.ADMIN_PASSWORD.SESSION_TIMEOUT_MINUTES' | translate}}</label>
+                        <input type="number" min="0" step="1"
+                               ng-model="vm.sessionTimeoutMinutes"
+                               aria-label="{{'ADMINCONSOLE.ADMIN_PASSWORD.SESSION_TIMEOUT_MINUTES' | translate}}">
+                    </md-input-container>
+                    <md-button class="md-raised md-secondary"
+                               ng-click="vm.saveSessionTimeout()"
+                               ng-disabled="vm.isSavingSessionTimeout || vm.sessionTimeoutMinutes < 0">
+                        {{'ADMINCONSOLE.ADMIN_PASSWORD.ACTION.SAVE' | translate}}
+                    </md-button>
+                </div>
+            </div>
         </div>
 
     </div>

--- a/eblocker-ui/src/settings/app/components/system/adminPassword/admin-password.component.js
+++ b/eblocker-ui/src/settings/app/components/system/adminPassword/admin-password.component.js
@@ -25,12 +25,18 @@ function AdminPasswordController(logger, $mdDialog, $translate,
     'ngInject';
 
     const vm = this;
+    const SECONDS_PER_MINUTE = 60;
 
     vm.openChangePasswordDialog = openChangePasswordDialog;
     vm.togglePasswordRequired = togglePasswordRequired;
     vm.changePassword = changePassword;
+    vm.saveSessionTimeout = saveSessionTimeout;
 
     vm.enabled = security.isPasswordRequired();
+    vm.sessionTimeoutMinutes = 20;
+    vm.isSavingSessionTimeout = false;
+
+    loadAdminConsoleSettings();
 
     function togglePasswordRequired() {
         if (security.isPasswordRequired()) {
@@ -56,6 +62,46 @@ function AdminPasswordController(logger, $mdDialog, $translate,
     function changePassword() {
         openChangePasswordDialog(true).then(function success() {
             NotificationService.info('ADMINCONSOLE.ADMIN_PASSWORD.NOTIFICATION.INFO_PASSWORD_CHANGED');
+        });
+    }
+
+    function loadAdminConsoleSettings() {
+        if (!angular.isFunction(security.getSettings)) {
+            return;
+        }
+        security.getSettings().then(function success(response) {
+            setSessionTimeoutMinutes(response.data.sessionTimeoutSeconds);
+        }, function error(response) {
+            logger.error('Unable to load admin console settings ', response);
+        });
+    }
+
+    function setSessionTimeoutMinutes(seconds) {
+        if (angular.isNumber(seconds) && seconds >= 0) {
+            vm.sessionTimeoutMinutes = seconds / SECONDS_PER_MINUTE;
+        }
+    }
+
+    function saveSessionTimeout() {
+        const minutes = angular.isNumber(vm.sessionTimeoutMinutes) ? vm.sessionTimeoutMinutes :
+            parseInt(vm.sessionTimeoutMinutes, 10);
+        const normalizedMinutes = isNaN(minutes) ? 0 : Math.max(0, Math.floor(minutes));
+        const settings = {
+            sessionTimeoutSeconds: normalizedMinutes * SECONDS_PER_MINUTE
+        };
+
+        vm.sessionTimeoutMinutes = normalizedMinutes;
+        vm.isSavingSessionTimeout = true;
+        return security.setSettings(settings).then(function success(response) {
+            setSessionTimeoutMinutes(response.data.sessionTimeoutSeconds);
+            NotificationService.info('ADMINCONSOLE.ADMIN_PASSWORD.NOTIFICATION.INFO_SESSION_TIMEOUT_CHANGED');
+        }, function error(response) {
+            NotificationService.error(
+                'ADMINCONSOLE.ADMIN_PASSWORD.NOTIFICATION.ERROR_SESSION_TIMEOUT_CHANGED',
+                response
+            );
+        }).finally(function() {
+            vm.isSavingSessionTimeout = false;
         });
     }
 

--- a/eblocker-ui/src/settings/app/service/security/security.service.js
+++ b/eblocker-ui/src/settings/app/service/security/security.service.js
@@ -23,6 +23,7 @@ export default function SecurityService(logger, $http, $q, $localStorage, APP_CO
     const PATH_RENEW_TOKEN = PATH +  '/renew/';
     const PATH_LOGIN = PATH + '/login/';
     const PATH_LOGIN_COUNTDOWN = PATH + '/wait';
+    const PATH_SETTINGS = PATH + '/settings';
 
     const securityContext = {};
 
@@ -87,6 +88,24 @@ export default function SecurityService(logger, $http, $q, $localStorage, APP_CO
         });
     }
 
+    function getSettings() {
+        return $http.get(PATH_SETTINGS, {timeout: 3000}).then(function success(response) {
+            return response;
+        }, function error(response) {
+            logger.error('Getting admin console settings failed with status ' + response.status, response);
+            return $q.reject(response);
+        });
+    }
+
+    function setSettings(settings) {
+        return $http.put(PATH_SETTINGS, settings, {timeout: 3000}).then(function success(response) {
+            return response;
+        }, function error(response) {
+            logger.error('Saving admin console settings failed with status ' + response.status, response);
+            return $q.reject(response);
+        });
+    }
+
     function storeSecurityContext(data) {
         securityContext.token = data.token;
         securityContext.appContext = data.appContext;
@@ -140,6 +159,8 @@ export default function SecurityService(logger, $http, $q, $localStorage, APP_CO
         isPasswordRequired: isPasswordRequired,
         login: login,
         logout: logout,
-        isLoginAvailable: isLoginAvailable
+        isLoginAvailable: isLoginAvailable,
+        getSettings: getSettings,
+        setSettings: setSettings
     };
 }

--- a/eblocker-ui/src/settings/app/settings.component.js
+++ b/eblocker-ui/src/settings/app/settings.component.js
@@ -25,12 +25,13 @@ export default {
 };
 
 function Controller($scope, $mdSidenav, STATES, StateService, SplashService, ConsoleService, $mdDialog, // jshint ignore: line
-                     logger, security, Idle, Title) {
+                     logger, security, Idle, Title, IDLE_TIMES) {
     'ngInject';
     'use strict';
 
     const vm = this;
     let idleDialog;
+    let sessionTimeoutSeconds = IDLE_TIMES.IDLE;
 
     vm.showSpinner = function() {
         return ConsoleService.isGlobalSpinner();
@@ -75,6 +76,7 @@ function Controller($scope, $mdSidenav, STATES, StateService, SplashService, Con
         vm.isLoading = true;
         document.addEventListener('visibilitychange', visibilityChanged);
         vm.navBarName = 'left';
+        loadAdminConsoleSettings();
 
         logger.info('Setting language to \'' + vm.locale.language + '\'');
 
@@ -99,6 +101,10 @@ function Controller($scope, $mdSidenav, STATES, StateService, SplashService, Con
 
     $scope.$on('IdleStart', function () {
         logger.info('No user interaction for a while. Idle started...');
+        if (isSessionTimeoutDisabled()) {
+            Idle.interrupt();
+            return;
+        }
         if (security.isPasswordRequired()) {
             idleDialog = $mdDialog.show({
                 controller: 'IdleDialogController',
@@ -129,8 +135,7 @@ function Controller($scope, $mdSidenav, STATES, StateService, SplashService, Con
         if (security.isPasswordRequired()) {
             logger.info('... idle timed out. Logging out...');
             security.logout();
-            StateService.goToState(STATES.EXPIRED);
-            // StateService.goToState(STATES.AUTH);
+            StateService.goToState(STATES.AUTH);
         } else {
             logger.info('... idle timed out. Restarting idle...');
             // ** No password needed, just start again
@@ -197,6 +202,33 @@ function Controller($scope, $mdSidenav, STATES, StateService, SplashService, Con
 
     function hideLogoutInMenu() {
         return !showLogout();
+    }
+
+    function loadAdminConsoleSettings() {
+        if (!angular.isFunction(security.getSettings)) {
+            applySessionTimeout(sessionTimeoutSeconds);
+            return;
+        }
+        security.getSettings().then(function success(response) {
+            applySessionTimeout(response.data.sessionTimeoutSeconds);
+        }, function error() {
+            applySessionTimeout(sessionTimeoutSeconds);
+        });
+    }
+
+    function applySessionTimeout(seconds) {
+        sessionTimeoutSeconds = angular.isNumber(seconds) && seconds >= 0 ? seconds : IDLE_TIMES.IDLE;
+        if (isSessionTimeoutDisabled()) {
+            Idle.setIdle(IDLE_TIMES.IDLE);
+            Idle.setTimeout(false);
+        } else {
+            Idle.setIdle(sessionTimeoutSeconds);
+            Idle.setTimeout(IDLE_TIMES.TIMEOUT);
+        }
+    }
+
+    function isSessionTimeoutDisabled() {
+        return sessionTimeoutSeconds === 0;
     }
 
     function handleSystemStatus(systemStatus) {

--- a/eblocker-ui/src/settings/app/settings.component.spec.js
+++ b/eblocker-ui/src/settings/app/settings.component.spec.js
@@ -1,0 +1,126 @@
+/*
+ * Copyright 2020 eBlocker Open Source UG (haftungsbeschraenkt)
+ *
+ * Licensed under the EUPL, Version 1.2 or - as soon they will be
+ * approved by the European Commission - subsequent versions of the EUPL
+ * (the "License"); You may not use this work except in compliance with
+ * the License. You may obtain a copy of the License at:
+ *
+ *   https://joinup.ec.europa.eu/page/eupl-text-11-12
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+import 'angular-mocks';
+
+/* global spyOn */
+
+describe('App settings; Settings component controller', function() {
+    beforeEach(angular.mock.module('template.settings.app'));
+    beforeEach(angular.mock.module('eblocker.adminconsole'));
+
+    let ctrl, scope, STATES, StateService, security, Idle, mdDialog, adminConsoleSettings;
+
+    StateService = {
+        goToState: angular.noop,
+        getActiveState: function() { return {}; }
+    };
+
+    security = {
+        isPasswordRequired: function() { return true; },
+        isAuthenticated: function() { return true; },
+        logout: angular.noop,
+        renewToken: function() {
+            return {
+                then: angular.noop
+            };
+        },
+        getSettings: function() {
+            return {
+                then: function(success) {
+                    success({data: adminConsoleSettings});
+                }
+            };
+        },
+        storeSecurityContext: angular.noop
+    };
+
+    Idle = {
+        interrupt: angular.noop,
+        watch: angular.noop,
+        setIdle: angular.noop,
+        setTimeout: angular.noop
+    };
+
+    mdDialog = {
+        show: angular.noop,
+        cancel: angular.noop
+    };
+
+    beforeEach(angular.mock.module(function($provide, $translateProvider) {
+        $provide.value('StateService', StateService);
+        $provide.value('security', security);
+        $provide.value('Idle', Idle);
+        $provide.value('Title', { setEnabled: angular.noop });
+        $provide.value('ConsoleService', {
+            isGlobalSpinner: function() { return false; },
+            goToDashboard: angular.noop,
+            goToStaticHelp: angular.noop,
+            showDashboardButton: function() { return true; }
+        });
+        $provide.value('SplashService', {});
+        $provide.value('$mdDialog', mdDialog);
+        $provide.value('$mdSidenav', function() {
+            return {
+                toggle: angular.noop
+            };
+        });
+        $translateProvider.translations('en', {});
+    }));
+
+    beforeEach(inject(function($rootScope, _$componentController_, _STATES_) {
+        scope = $rootScope.$new();
+        adminConsoleSettings = {sessionTimeoutSeconds: 1200};
+        STATES = _STATES_;
+        spyOn(StateService, 'goToState');
+        spyOn(security, 'logout');
+        ctrl = _$componentController_('settingsComponent', {$scope: scope}, {});
+    }));
+
+    describe('initially', function() {
+        it('should create a controller instance', function() {
+            expect(angular.isDefined(ctrl)).toBe(true);
+        });
+    });
+
+    describe('on idle timeout', function() {
+        it('should log out and redirect directly to the login screen when a password is required', function() {
+            scope.$broadcast('IdleTimeout');
+
+            expect(security.logout).toHaveBeenCalled();
+            expect(StateService.goToState).toHaveBeenCalledWith(STATES.AUTH);
+            expect(StateService.goToState).not.toHaveBeenCalledWith(STATES.EXPIRED);
+        });
+    });
+
+    describe('on idle start', function() {
+        it('should not show an idle dialog when session timeout is disabled', function() {
+            adminConsoleSettings.sessionTimeoutSeconds = 0;
+            ctrl.systemStatus = {executionState: 'OK'};
+            ctrl.locale = {language: 'en'};
+            spyOn(Idle, 'setTimeout');
+            spyOn(Idle, 'interrupt');
+            spyOn(mdDialog, 'show');
+
+            ctrl.$onInit();
+            scope.$broadcast('IdleStart');
+
+            expect(Idle.setTimeout).toHaveBeenCalledWith(false);
+            expect(Idle.interrupt).toHaveBeenCalled();
+            expect(mdDialog.show).not.toHaveBeenCalled();
+        });
+    });
+});


### PR DESCRIPTION
## Summary
- Add persistent admin console settings with configurable session timeout.
- Add Admin Password UI controls to set the timeout in minutes; `0` disables automatic logout.
- Apply the configured timeout to the settings app idle handling and redirect directly to login after timeout instead of the expired intermediate screen.
- Add German and English translations for the new UI text.

Fixes #415

## Test Plan
- `OPENSSL_CONF=/dev/null npm test -- --single-run` → 281 tests successful
- `OPENSSL_CONF=/dev/null npx gulp build` → successful, includes vet/build and 281 Karma tests
- `mvn -pl eblocker-icapserver -Dtest=SecurityServiceTest test` → 13 tests successful
- `mvn -pl eblocker-icapserver -Dtest='!org.eblocker.server.common.network.unix.NetworkInterfaceAliasesTest' test` → 2041 tests, 0 failures/errors, 6 skipped
