### PR TITLE
fix: remember devices table sort state

### DIFF
--- a/eblocker-ui/src/settings/app/components/table/table.component.js
+++ b/eblocker-ui/src/settings/app/components/table/table.component.js
@@ -166,6 +166,7 @@ function Controller(logger, $scope, $window, $translate, StateService, TableServ
             vm.oldOrderKey = vm.orderKey;
             vm.orderKey = key;
         }
+        TableService.setTableSortState(vm.tableId, vm.orderKey, vm.reverseOrder, vm.oldOrderKey);
         vm.tableData = updateTable(doReverse, vm.oldOrderKey, vm.tableData);
     }
 
@@ -357,21 +358,28 @@ function Controller(logger, $scope, $window, $translate, StateService, TableServ
             vm.isEntrySelectable = function() { return true; };
         }
 
-        // ** Find default sorting
-        vm.tableHeader.forEach((header, index) => {
-            if (index === 1 && angular.isUndefined(vm.orderKey)) {
-                // defaults to second header, which is usually the one after the icon.
-                vm.orderKey = header.sortingKey;
-                vm.reverseOrder = angular.isDefined(header.isReversed) ? header.isReversed : false;
-            }
-            if (header.defaultSorting) {
-                vm.orderKey = header.sortingKey;
-                vm.reverseOrder = angular.isDefined(header.isReversed) ? header.isReversed : false;
-            }
-            if (header.secondSorting) {
-                vm.oldOrderKey = header.sortingKey;
-            }
-        });
+        const storedSortState = TableService.getTableSortState(vm.tableId);
+        if (angular.isObject(storedSortState) && angular.isString(storedSortState.orderKey)) {
+            vm.orderKey = storedSortState.orderKey;
+            vm.reverseOrder = storedSortState.reverseOrder === true;
+            vm.oldOrderKey = storedSortState.oldOrderKey;
+        } else {
+            // ** Find default sorting
+            vm.tableHeader.forEach((header, index) => {
+                if (index === 1 && angular.isUndefined(vm.orderKey)) {
+                    // defaults to second header, which is usually the one after the icon.
+                    vm.orderKey = header.sortingKey;
+                    vm.reverseOrder = angular.isDefined(header.isReversed) ? header.isReversed : false;
+                }
+                if (header.defaultSorting) {
+                    vm.orderKey = header.sortingKey;
+                    vm.reverseOrder = angular.isDefined(header.isReversed) ? header.isReversed : false;
+                }
+                if (header.secondSorting) {
+                    vm.oldOrderKey = header.sortingKey;
+                }
+            });
+        }
 
         // ** Set table's initial sorting.
         // We need to do sorting manually, so that we can reset the striped flags.

--- a/eblocker-ui/src/settings/app/components/table/table.component.spec.js
+++ b/eblocker-ui/src/settings/app/components/table/table.component.spec.js
@@ -20,7 +20,7 @@ describe('App settings; Table component controller', function() {
     beforeEach(angular.mock.module('template.settings.app'));
     beforeEach(angular.mock.module('eblocker.adminconsole'));
 
-    let ctrl, $componentController;
+    let ctrl, $componentController, TableService;
 
     beforeEach(angular.mock.module(function($provide, $translateProvider) {
         // Workaround angular-translate issue:
@@ -28,10 +28,40 @@ describe('App settings; Table component controller', function() {
         $translateProvider.translations('en', {});
     }));
 
-    beforeEach(inject(function(_$componentController_) {
+    beforeEach(inject(function(_$componentController_, _TableService_) {
         $componentController = _$componentController_;
+        TableService = _TableService_;
         ctrl = $componentController('ebTable', {}, {});
     }));
+
+    function createTable(tableId) {
+        const table = $componentController('ebTable', {}, {
+            tableId: tableId,
+            tableHeader: [
+                {
+                    label: 'Default',
+                    sortingKey: 'name',
+                    defaultSorting: true
+                },
+                {
+                    label: 'Last online',
+                    sortingKey: 'lastSeen'
+                }
+            ],
+            tableData: [
+                {
+                    name: 'Alpha',
+                    lastSeen: 2
+                },
+                {
+                    name: 'Beta',
+                    lastSeen: 1
+                }
+            ]
+        });
+        table.$onInit();
+        return table;
+    }
 
     describe('function isReducedWidth', function() {
         it('return false if edit mode is not set and details view is not defined', function() {
@@ -50,6 +80,21 @@ describe('App settings; Table component controller', function() {
             // this state shows the checkmark, but hides the details view icon, so it does not matter whether
             // the second param is true or false, once the first is true.
             expect(ctrl.isReducedWidth(true, true)).toBe(true);
+        });
+    });
+
+    describe('table sorting', function() {
+        it('restores changed sort column and order for the same table', function() {
+            const tableId = TableService.getUniqueTableId('devices-table');
+            const firstTable = createTable(tableId);
+
+            firstTable.changeOrder('lastSeen');
+            firstTable.changeOrder('lastSeen');
+
+            const secondTable = createTable(tableId);
+
+            expect(secondTable.orderKey).toBe('lastSeen');
+            expect(secondTable.reverseOrder).toBe(true);
         });
     });
 });

--- a/eblocker-ui/src/settings/app/service/table/TableService.js
+++ b/eblocker-ui/src/settings/app/service/table/TableService.js
@@ -39,6 +39,7 @@ export default function TableService(logger, $window) {
 
     const largeTableVisibleItems = {};
     const smallTableVisibleItems = {};
+    const tableSortStates = {};
     const prefixCounter = {};
 
     let idCounter = 1;
@@ -136,12 +137,31 @@ export default function TableService(logger, $window) {
         return isSmallScreen() ? smallTableVisibleItems[tableId] : largeTableVisibleItems[tableId];
     }
 
+    function setTableSortState(tableId, orderKey, reverseOrder, oldOrderKey) {
+        if (angular.isString(tableId) && angular.isString(orderKey)) {
+            tableSortStates[tableId] = {
+                orderKey: orderKey,
+                reverseOrder: reverseOrder === true,
+                oldOrderKey: oldOrderKey
+            };
+        }
+    }
+
+    function getTableSortState(tableId) {
+        if (angular.isString(tableId) && angular.isObject(tableSortStates[tableId])) {
+            return angular.copy(tableSortStates[tableId]);
+        }
+        return undefined;
+    }
+
     return {
         getUniqueTableId: getUniqueTableId,
         getLargeTableRowHeight: getLargeTableRowHeight,
         getSmallTableRowHeight: getSmallTableRowHeight,
         tableNumVisibleItems: tableNumVisibleItems,
         getTablePaginatorOptions: getTablePaginatorOptions,
-        getNumOfVisibleItems: getNumOfVisibleItems
+        getNumOfVisibleItems: getNumOfVisibleItems,
+        setTableSortState: setTableSortState,
+        getTableSortState: getTableSortState
     };
 }


### PR DESCRIPTION
## Summary
- Remember the current `ebTable` sort column and direction per table ID in `TableService`.
- Restore the saved sort state when the same table is recreated, e.g. when returning from device details to the devices table.
- Add a regression test covering sort-state restoration for the devices table ID.

## Test Plan
- [x] `OPENSSL_CONF=/dev/null npm test -- --single-run`
- [x] `OPENSSL_CONF=/dev/null npx gulp build`

Fixes #411
