### PR TITLE
Fix dashboard error for unknown client IP

### DIFF
--- a/eblocker-ui/src/dashboard/app/_bootstrap/_configs/routeConfig.js
+++ b/eblocker-ui/src/dashboard/app/_bootstrap/_configs/routeConfig.js
@@ -53,15 +53,17 @@ export default function AppRouter($stateProvider, $urlRouterProvider) {
                 // 'token' needed only indirectly for the REST call
                 return DeviceService.getDevice().then(function success(response) {
                     return response.data;
+                }, function error() {
+                    return null;
                 });
             }],
             operatingUser: ['token', 'device', 'UserService', function(token, device, UserService) {
                 // 'token' needed only indirectly for the REST call
-                return UserService.getUsers(true).then(function success(response) {
-                    if (angular.isObject(device)) {
-                        return UserService.getUserById(device.operatingUser);
-                    }
+                if (!angular.isObject(device)) {
                     return null;
+                }
+                return UserService.getUsers(true).then(function success(response) {
+                    return UserService.getUserById(device.operatingUser);
                 });
             }],
             initSelectedDevice: ['device', 'DeviceSelectorService', function(device, DeviceSelectorService) {

--- a/eblocker-ui/src/dashboard/app/dashboard.component.js
+++ b/eblocker-ui/src/dashboard/app/dashboard.component.js
@@ -125,7 +125,7 @@ function AppController($scope, $state, $stateParams, $location, $window, $docume
     }
 
     function isDashboardPaused() {
-        return !DataService.isRunning() && isMainState();
+        return angular.isObject(DeviceSelectorService.getSelectedDevice()) && !DataService.isRunning() && isMainState();
     }
 
     function isServerNotRunning() {

--- a/eblocker-ui/src/dashboard/app/main.component.html
+++ b/eblocker-ui/src/dashboard/app/main.component.html
@@ -6,7 +6,16 @@
     <md-progress-circular md-diameter="36"></md-progress-circular>
 </div>
 
-<div ng-if="vm.initFinished"
+<div ng-if="vm.initFinished && vm.hasDashboardError()"
+     layout="row" layout-align="center start"
+     class="dashboard-main-screen">
+    <md-content class="md-whiteframe-1dp" layout-padding>
+        <h2 translate="APP.DASHBOARD_ERROR.TITLE"></h2>
+        <p translate="APP.DASHBOARD_ERROR.MESSAGE"></p>
+    </md-content>
+</div>
+
+<div ng-if="vm.initFinished && !vm.hasDashboardError()"
      layout="row" layout-align="center start"
      class="dashboard-main-screen"
      ng-class="vm.getScreenClass()">

--- a/eblocker-ui/src/dashboard/app/main.component.js
+++ b/eblocker-ui/src/dashboard/app/main.component.js
@@ -35,6 +35,7 @@ function MainController(logger, $document, $window, $timeout, $interval, $filter
     const vm = this;
 
     vm.isTouchDevice = isTouchDevice;
+    vm.hasDashboardError = hasDashboardError;
 
     // Allows for smoother resizing:
     // only resize every n milliseconds (see timeout wrapper)
@@ -76,11 +77,18 @@ function MainController(logger, $document, $window, $timeout, $interval, $filter
     }
 
     vm.$onInit = function() {
+        vm.initFinished = false;
+
+        if (hasDashboardError()) {
+            logger.error('Cannot initialize dashboard: local device could not be resolved.');
+            vm.initFinished = true;
+            return;
+        }
+
         // Callback to execute when CardService makes a change from another component (dashboard.component.js has
         // dropdown list and updates the visibility. We want to react by re-rendering the dashboard).
         CardService.registerUpdateListener(updateVisibility);
 
-        vm.initFinished = false;
         angular.element($window).on('resize', resizeWrapper);
 
         addIdleTimeoutEventListeners();
@@ -152,6 +160,10 @@ function MainController(logger, $document, $window, $timeout, $interval, $filter
                 vm.columns = CardService.getCardsByColumns();
             }
         });
+    }
+
+    function hasDashboardError() {
+        return !angular.isObject(vm.device);
     }
 
     function isTouchDevice() {

--- a/eblocker-ui/src/dashboard/app/main.component.spec.js
+++ b/eblocker-ui/src/dashboard/app/main.component.spec.js
@@ -14,10 +14,11 @@
  * implied. See the License for the specific language governing
  * permissions and limitations under the License.
  */
+/* global spyOn */
 describe('Dashboard Main controller', function() { // jshint ignore: line
     beforeEach(angular.mock.module('eblocker.dashboard'));
 
-    let ctrl, $componentController, mockPauseCard, mockSslCard, mockOnlineCard, mockDeviceCard, $httpBackend;
+    let ctrl, $componentController, mockPauseCard, mockSslCard, mockOnlineCard, mockDeviceCard, $q;
 
     const mockLocale = {
         language: 'en'
@@ -25,7 +26,10 @@ describe('Dashboard Main controller', function() { // jshint ignore: line
 
     const mockDataService = {
         on: angular.noop,
-        off: angular.noop
+        off: angular.noop,
+        isRunning: function() {
+            return false;
+        }
     };
 
     const mockCardAvailabilityService = {
@@ -50,8 +54,22 @@ describe('Dashboard Main controller', function() { // jshint ignore: line
     };
 
     const mockCardService = {
+        registerUpdateListener: angular.noop,
+        getDashboardData: angular.noop,
         getFilterCards: function () {
             return [mockPauseCard, mockSslCard, mockOnlineCard, mockDeviceCard];
+        },
+        getCardsByColumns: function() {
+            return [];
+        },
+        scheduleDashboardReload: function() {
+            return false;
+        }
+    };
+
+    const mockResolutionService = {
+        getScreenSize: function() {
+            return 'lg';
         }
     };
 
@@ -63,9 +81,11 @@ describe('Dashboard Main controller', function() { // jshint ignore: line
         $provide.value('CardAvailabilityService', mockCardAvailabilityService);
         $provide.value('$window', mockWindow);
         $provide.value('CardService', mockCardService);
+        $provide.value('ResolutionService', mockResolutionService);
     }));
 
-    beforeEach(inject(function($rootScope, $controller, _$componentController_, _$httpBackend_) {
+    beforeEach(inject(function(_$q_, _$componentController_) {
+        $q = _$q_;
         mockPauseCard = {
             id: 1,
             input: '<dashboard-pause></dashboard-pause>',
@@ -142,7 +162,6 @@ describe('Dashboard Main controller', function() { // jshint ignore: line
             }
         };
 
-        // $httpBackend = _$httpBackend_;
         //
         // const cards = [mockPauseCard, mockSslCard, mockOnlineCard, mockDeviceCard];
         // $httpBackend.when('GET', '/api/dashboardcard').respond(200, cards);
@@ -151,13 +170,42 @@ describe('Dashboard Main controller', function() { // jshint ignore: line
 
 
         $componentController = _$componentController_;
-        ctrl = $componentController('mainComponent', {}, {});
+        mockCardService.getDashboardData = function() {
+            return $q.resolve(false);
+        };
+        ctrl = $componentController('mainComponent', {}, {
+            device: {
+                showBookmarkDialog: false
+            },
+            productInfo: mockProductInfo
+        });
         // $httpBackend.flush();
     }));
 
     describe('initially', function() {
         it('should create a controller instance', function() {
             expect(angular.isDefined(ctrl)).toBe(true);
+        });
+    });
+
+    describe('unknown local device', function() {
+        it('shows a dashboard error without starting dashboard services', function() {
+            spyOn(mockDataService, 'on').and.callThrough();
+            spyOn(mockCardService, 'getDashboardData').and.callThrough();
+
+            ctrl = $componentController('mainComponent', {}, {
+                device: null,
+                productInfo: mockProductInfo
+            });
+
+            expect(function() {
+                ctrl.$onInit();
+            }).not.toThrow();
+
+            expect(ctrl.hasDashboardError()).toBe(true);
+            expect(ctrl.initFinished).toBe(true);
+            expect(mockDataService.on).not.toHaveBeenCalled();
+            expect(mockCardService.getDashboardData).not.toHaveBeenCalled();
         });
     });
 

--- a/eblocker-ui/src/dashboard/app/service/devices/deviceSelector.service.js
+++ b/eblocker-ui/src/dashboard/app/service/devices/deviceSelector.service.js
@@ -68,6 +68,7 @@ export default function DeviceSelectorService($rootScope, $state, $stateParams, 
             return ArrayUtilsService.sortByProperty(devices, 'name');
         }, function(reason) {
             logger.error('Failed: ' + JSON.stringify(reason));
+            return [];
         });
     }
 

--- a/eblocker-ui/src/locale/lang-dashboard-de.json
+++ b/eblocker-ui/src/locale/lang-dashboard-de.json
@@ -27,6 +27,10 @@
             "SELECT_LOCAL": "Dieses Gerät",
             "SELECT_OTHER": "Andere Geräte..."
         },
+        "DASHBOARD_ERROR": {
+            "MESSAGE": "Der eBlocker konnte dieses Gerät nicht identifizieren. Bitte überprüfe die Netzwerkverbindung und versuche es erneut.",
+            "TITLE": "Dashboard ist nicht verfügbar"
+        },
         "DRAG_DROP": {
             "TOOLTIP": "Ziehe hier, um die Karte umzusortieren."
         },

--- a/eblocker-ui/src/locale/lang-dashboard-en.json
+++ b/eblocker-ui/src/locale/lang-dashboard-en.json
@@ -27,6 +27,10 @@
             "SELECT_LOCAL" : "This device",
             "SELECT_OTHER" : "Other devices..."
         },
+        "DASHBOARD_ERROR" : {
+            "MESSAGE" : "The eBlocker could not identify this device. Please check the network connection and try again.",
+            "TITLE" : "Dashboard is not available"
+        },
         "DRAG_DROP" : {
             "TOOLTIP" : "Drag here to reorder this card."
         },


### PR DESCRIPTION
## Summary
- Allow the dashboard route to render when the local device cannot be resolved, instead of staying on a blank/loading page.
- Show a localized dashboard error message when the eBlocker cannot identify the client device.
- Avoid starting dashboard data/card services and suppress the paused-dashboard overlay in that error state.
- Make the dashboard device dropdown robust if the device list cannot be loaded.

## Tests
- `OPENSSL_CONF=/dev/null npm test -- --single-run`
- `OPENSSL_CONF=/dev/null npx gulp build`
- `git diff --check`
- JSON parse check for `lang-dashboard-en.json` and `lang-dashboard-de.json`
