### PR TITLE
Only write filter stores with valid IDs

### DIFF
--- a/eblocker-icapserver/src/main/java/org/eblocker/server/icap/filter/FilterManager.java
+++ b/eblocker-icapserver/src/main/java/org/eblocker/server/icap/filter/FilterManager.java
@@ -28,6 +28,7 @@ import org.eblocker.crypto.json.JSONCryptoHandler;
 import org.eblocker.crypto.keys.KeyWrapper;
 import org.eblocker.server.common.data.DataSource;
 import org.eblocker.server.common.data.systemstatus.SubSystem;
+import org.eblocker.server.common.exceptions.EblockerException;
 import org.eblocker.server.common.startup.SubSystemInit;
 import org.eblocker.server.common.startup.SubSystemService;
 import org.eblocker.server.icap.filter.csv.CSVLineParser;
@@ -132,8 +133,6 @@ public class FilterManager {
     }
 
     public synchronized FilterStoreConfiguration addFilter(FilterStoreConfiguration configuration) {
-        FilterStore store = createFilterStore(configuration);
-
         int id = dataSource.nextId(FilterStoreConfiguration.class);
         FilterStoreConfiguration addedConfiguration = new FilterStoreConfiguration(id,
                 configuration.getName(),
@@ -146,6 +145,8 @@ public class FilterManager {
                 configuration.isLearnForAllDomains(),
                 configuration.getRuleFilters(),
                 configuration.isEnabled());
+
+        FilterStore store = createFilterStore(addedConfiguration);
 
         List<FilterStoreConfiguration> newConfigurations = new ArrayList<>(configurations);
         newConfigurations.add(addedConfiguration);
@@ -351,7 +352,13 @@ public class FilterManager {
     }
 
     private Path getPath(FilterStoreConfiguration configuration) {
-        return cacheDirectory.resolve(configuration.getId() + fileSuffix);
+        Integer id = configuration.getId();
+        if (id == null) {
+            String msg = "Cannot create path in cache directory for FilterStoreConfiguration without ID";
+            log.error(msg);
+            throw new EblockerException(msg);
+        }
+        return cacheDirectory.resolve(id + fileSuffix);
     }
 
     private FilterStore createFilterStore(FilterStoreConfiguration configuration) {

--- a/eblocker-icapserver/src/test/java/org/eblocker/server/icap/filter/FilterManagerTest.java
+++ b/eblocker-icapserver/src/test/java/org/eblocker/server/icap/filter/FilterManagerTest.java
@@ -179,6 +179,9 @@ public class FilterManagerTest {
         Assert.assertSame(savedConfiguration, manager.getFilterStoreConfigurationById(savedConfiguration.getId()));
         assertEquals(Decision.BLOCK, decisionForURL(manager.getFilter(Category.ADS), TRACKER_URL)); // Now the list has been updated with easyprivacy.txt
 
+        // check for issue with "null.json.enc" file
+        Assert.assertTrue(Files.exists(cacheDirectory.resolve(savedConfiguration.getId() + FILE_SUFFIX)));
+
         Mockito.verify(dataSource).nextId(FilterStoreConfiguration.class);
         Mockito.verify(dataSource).save(Mockito.any(FilterStoreConfiguration.class), Mockito.eq(savedConfiguration.getId()));
     }


### PR DESCRIPTION
Fixes the issue that a new custom filter store is first written with filename `null.json.enc`.